### PR TITLE
fix: add type="button" and aria-label to all control buttons

### DIFF
--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PlayBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PlayBtn.tsx
@@ -33,7 +33,12 @@ export const PlayBtn: FC = () => {
   }, [curAudioState.isPlaying, customIcons?.pause, customIcons?.play]);
 
   return (
-    <StyledPlayBtn onClick={changePlayState} className="play-button">
+    <StyledPlayBtn
+      type="button"
+      onClick={changePlayState}
+      className="play-button"
+      aria-label={curAudioState.isPlaying ? "Pause" : "Play"}
+    >
       {PlayIcon}
     </StyledPlayBtn>
   );

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PlayListTriggerBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PlayListTriggerBtn.tsx
@@ -12,7 +12,7 @@ export interface PlayListTriggerBtnProps {
 export const PlayListTriggerBtn: FC<PlayListTriggerBtnProps> = ({ isOpen }) => {
   const { customIcons } = useNonNullableContext(audioPlayerStateContext);
   return (
-    <StyledBtn>
+    <StyledBtn type="button" aria-label={isOpen ? "Close playlist" : "Open playlist"}>
       <Icon
         render={
           <MdPlaylistPlay

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
@@ -33,7 +33,12 @@ export const PrevNnextBtn: FC<PrevNnextBtnProps> = ({ type, visible }) => {
   }, [customIcons?.next, customIcons?.prev, type]);
 
   return visible ? (
-    <StyledBtn onClick={changeAudio} className="prev-n-next-button">
+    <StyledBtn
+      type="button"
+      onClick={changeAudio}
+      className="prev-n-next-button"
+      aria-label={type === "next" ? "Next track" : "Previous track"}
+    >
       {PrevNnextIcon}
     </StyledBtn>
   ) : null;

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
@@ -67,12 +67,30 @@ export const RepeatTypeBtn: FC = () => {
   ]);
 
   return (
+    customIcons?.repeatShuffle,
+  ]);
+
+  const repeatLabel = useMemo(() => {
+    switch (curAudioState.repeatType) {
+      case "ALL":     return "Repeat all";
+      case "ONE":     return "Repeat one";
+      case "NONE":    return "Repeat off";
+      case "SHUFFLE": return "Shuffle";
+      default:        return "Repeat";
+    }
+  }, [curAudioState.repeatType]);
+
+  return (
     <StyledBtn
       type="button"
       onClick={changeRepeatType}
       className="repeat-button"
-      aria-label={`Repeat: ${curAudioState.repeatType}`}
+      aria-label={repeatLabel}
     >
+      {RepeatIcon}
+    </StyledBtn>
+  );
+};
       {RepeatIcon}
     </StyledBtn>
   );

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
@@ -67,7 +67,12 @@ export const RepeatTypeBtn: FC = () => {
   ]);
 
   return (
-    <StyledBtn onClick={changeRepeatType} className="repeat-button">
+    <StyledBtn
+      type="button"
+      onClick={changeRepeatType}
+      className="repeat-button"
+      aria-label={`Repeat: ${curAudioState.repeatType}`}
+    >
       {RepeatIcon}
     </StyledBtn>
   );

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/VolumeTriggerBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/VolumeTriggerBtn.tsx
@@ -70,8 +70,10 @@ export const VolumeTriggerBtn = forwardRef<HTMLButtonElement>((_, ref) => {
   ]);
   return (
     <StyledBtn
+      type="button"
       onClick={changeMuteState}
       className="volume-trigger-container"
+      aria-label={curAudioState.muted ? "Unmute" : "Mute"}
       ref={ref}
     >
       {VolumeIcon}


### PR DESCRIPTION
## Summary

- Add `type="button"` to all player control buttons
- Add `aria-label` attributes for accessibility

## Problem

When `AudioPlayer` is placed inside a `<form>` element, clicking any control button triggers form submission because buttons default to `type="submit"`.

Closes #10

## Changes

| File | Fix |
|------|-----|
| `PlayBtn.tsx` | `type="button"`, `aria-label` Play/Pause |
| `PrevNnextBtn.tsx` | `type="button"`, `aria-label` Previous/Next track |
| `RepeatTypeBtn.tsx` | `type="button"`, `aria-label` with current repeat state |
| `PlayListTriggerBtn.tsx` | `type="button"`, `aria-label` Open/Close playlist |
| `VolumeTriggerBtn.tsx` | `type="button"`, `aria-label` Mute/Unmute |

## Test Plan

- [ ] Wrap `<AudioPlayer />` inside a `<form>` — clicking buttons should not submit the form
- [ ] Verify screen readers announce button labels correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Accessibility Improvements**
  * Enhanced audio player interface with improved accessibility across all button controls (play/pause, playlist, track navigation, repeat, volume). Added semantic button attributes and descriptive screen reader labels to support better keyboard navigation and compatibility with assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->