### PR TITLE
fix: prevent Next.js SSR 'self is not defined' crash

### DIFF
--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -3,7 +3,6 @@ import { useVariableColor } from "@/hooks/useVariableColor";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
 import { audioPlayerStateContext } from "@/components/AudioPlayer/Context/StateContext";
 import { useEffect } from "react";
-import WaveSurfer from "wavesurfer.js";
 
 const waveformColors = {
   progressColor: "--rm-audio-player-waveform-bar",
@@ -22,24 +21,38 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
   /** init waveSurfer */
   useEffect(() => {
     if (elementRefs?.waveformInst || !colorsRef.current) return;
+    if (typeof window === "undefined") return;
 
-    const waveSurfer = WaveSurfer.create({
-      barWidth: 1,
-      cursorWidth: 2,
-      container: "#rm-waveform",
-      height: 80,
-      progressColor: `${colorsRef.current.progressColor}`,
-      responsive: true,
-      waveColor: `${colorsRef.current.waveColor}`,
-      cursorColor: "var(--rm-audio-player-waveform-cursor)",
-      backend: "MediaElement",
-      removeMediaElementOnDestroy: false,
-    });
+    let isCancelled = false;
 
-    audioPlayerDispatch({
-      type: "SET_ELEMENT_REFS",
-      elementRefs: { waveformInst: waveSurfer },
-    });
+    const initWaveSurfer = async () => {
+      const { default: WaveSurfer } = await import("wavesurfer.js");
+      if (isCancelled) return;
+
+      const waveSurfer = WaveSurfer.create({
+        barWidth: 1,
+        cursorWidth: 2,
+        container: "#rm-waveform",
+        height: 80,
+        progressColor: `${colorsRef.current?.progressColor}`,
+        responsive: true,
+        waveColor: `${colorsRef.current?.waveColor}`,
+        cursorColor: "var(--rm-audio-player-waveform-cursor)",
+        backend: "MediaElement",
+        removeMediaElementOnDestroy: false,
+      });
+
+      audioPlayerDispatch({
+        type: "SET_ELEMENT_REFS",
+        elementRefs: { waveformInst: waveSurfer },
+      });
+    };
+
+    void initWaveSurfer();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [elementRefs?.waveformInst, audioPlayerDispatch, colorsRef]);
 
   // TODO : preserve audio state when loading new audio

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -26,26 +26,35 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     let isCancelled = false;
 
     const initWaveSurfer = async () => {
-      const { default: WaveSurfer } = await import("wavesurfer.js");
-      if (isCancelled) return;
+      try {
+        const { default: WaveSurfer } = await import("wavesurfer.js");
+        if (isCancelled) return;
 
-      const waveSurfer = WaveSurfer.create({
-        barWidth: 1,
-        cursorWidth: 2,
-        container: "#rm-waveform",
-        height: 80,
-        progressColor: `${colorsRef.current?.progressColor}`,
-        responsive: true,
-        waveColor: `${colorsRef.current?.waveColor}`,
-        cursorColor: "var(--rm-audio-player-waveform-cursor)",
-        backend: "MediaElement",
-        removeMediaElementOnDestroy: false,
-      });
+        const colors = colorsRef.current;
+        if (!colors) return;
 
-      audioPlayerDispatch({
-        type: "SET_ELEMENT_REFS",
-        elementRefs: { waveformInst: waveSurfer },
-      });
+        const waveSurfer = WaveSurfer.create({
+          barWidth: 1,
+          cursorWidth: 2,
+          container: "#rm-waveform",
+          height: 80,
+          progressColor: colors.progressColor,
+          responsive: true,
+          waveColor: colors.waveColor,
+          cursorColor: "var(--rm-audio-player-waveform-cursor)",
+          backend: "MediaElement",
+          removeMediaElementOnDestroy: false,
+        });
+
+        audioPlayerDispatch({
+          type: "SET_ELEMENT_REFS",
+          elementRefs: { waveformInst: waveSurfer },
+        });
+      } catch (error) {
+        if (!isCancelled) {
+          console.error("Failed to initialize WaveSurfer:", error);
+        }
+      }
     };
 
     void initWaveSurfer();


### PR DESCRIPTION
## Bug
https://github.com/slash9494/react-modern-audio-player/issues/20 — importing the package in Next.js 14 server context throws `ReferenceError: self is not defined`.

## Fix
`wavesurfer.js` was imported at module scope in `useWavesurfer.ts`, which evaluates during SSR import time.

This PR moves `wavesurfer.js` loading into the browser-only `useEffect` path (`typeof window !== "undefined"`) using a dynamic import. That keeps SSR imports safe while preserving existing client behavior.

## Testing
- Verified code path now avoids evaluating `wavesurfer.js` during SSR/module import.
- Verified waveform initialization still runs in the browser and dispatches `waveformInst` as before.

Happy to address any feedback.

Greetings, saschabuehrle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio player efficiency and stability by making waveform initialization asynchronous and safer during component lifecycle changes.
  * Prevents waveform setup when not running in a browser, reducing unnecessary work on server-side renders.
* **Bug Fixes**
  * Avoids race conditions and limits noisy errors if the player unmounts before initialization completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->