### PR TITLE
👷 ci(labeler): add issues: write permission for label management

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:


### PR DESCRIPTION
## Summary

Labeler action was not applying labels due to missing `issues: write` permission. GitHub's label API requires this permission to create and assign labels.

## Changes

- `.github/workflows/labeler.yml`: add `issues: write` to job permissions

## Test Results

- [ ] build passes
- [ ] lint passes
- [ ] tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions PR labeler workflow permissions to enable enhanced automation capabilities for issue management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->