### PR TITLE
👷 ci(reports): add e2e-report and security-guard-report to default branch

### DIFF
--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -1,0 +1,74 @@
+name: E2E Report
+
+on:
+  workflow_run:
+    workflows: ["E2E Tests"]
+    types: [completed]
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: e2e-pr-meta
+          path: e2e-pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Post E2E result comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let prNumber;
+            try {
+              prNumber = parseInt(fs.readFileSync('e2e-pr-meta/pr_number.txt', 'utf8').trim(), 10);
+            } catch {
+              core.warning('Could not read PR number — skipping comment');
+              return;
+            }
+
+            const conclusion = '${{ github.event.workflow_run.conclusion }}';
+            const icon = conclusion === 'success' ? '✅' : conclusion === 'failure' ? '❌' : '⚠️';
+            const status = conclusion === 'success'
+              ? 'All E2E tests passed.'
+              : conclusion === 'failure'
+              ? 'E2E tests failed. Download the report artifact for details.'
+              : `E2E job concluded with status: ${conclusion}`;
+
+            const body = `### ${icon} E2E Tests — ${conclusion}\n\n${status}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c =>
+              c.user?.login === 'github-actions[bot]' && c.body?.includes('E2E Tests')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -31,6 +31,7 @@ jobs:
             let prNumber;
             try {
               prNumber = parseInt(fs.readFileSync('e2e-pr-meta/pr_number.txt', 'utf8').trim(), 10);
+              if (isNaN(prNumber)) throw new Error('Invalid PR number');
             } catch {
               core.warning('Could not read PR number — skipping comment');
               return;

--- a/.github/workflows/security-guard-report.yml
+++ b/.github/workflows/security-guard-report.yml
@@ -1,0 +1,103 @@
+name: Security Guard Report
+
+on:
+  workflow_run:
+    workflows: ["Security Guard"]
+    types: [completed]
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download security review metadata
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: security-guard-meta
+          path: security-guard-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Post or update review checklist comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let prNumber, files;
+            try {
+              prNumber = parseInt(fs.readFileSync('security-guard-meta/pr_number.txt', 'utf8').trim(), 10);
+              files = fs.readFileSync('security-guard-meta/changed_files.txt', 'utf8').trim();
+            } catch {
+              core.info('No security review metadata found — skipping comment');
+              return;
+            }
+
+            const fileList = files.split('\n').map(f => `- \`${f}\``).join('\n');
+
+            const body = [
+              '## 🔒 Security Review Required',
+              '',
+              'Executable config files were modified. A maintainer must review these changes before merge.',
+              '',
+              '**To unblock:** complete the checklist below, then add the `security-reviewed` label.',
+              '',
+              '### Changed files',
+              fileList,
+              '',
+              '---',
+              '',
+              '### Reviewer Checklist',
+              '',
+              '**`package.json` / `package/package.json`**',
+              '- [ ] No `postinstall`, `preinstall`, or `prepare` scripts were added or modified',
+              '- [ ] No existing lifecycle scripts were changed to include shell commands or network calls',
+              '- [ ] No new dependencies that run install-time scripts',
+              '',
+              '**`playwright.config.ts`**',
+              '- [ ] `globalSetup` and `globalTeardown` were not added or modified',
+              '- [ ] `webServer.command` is unchanged or only points to the local dev server',
+              '- [ ] No `require()` or `import` of unfamiliar modules',
+              '- [ ] No `process.env` exfiltration patterns',
+              '',
+              '**`*.config.ts` (vite, vitest)**',
+              '- [ ] No use of `exec`, `spawn`, `execSync`, or `spawnSync`',
+              '- [ ] No dynamic `import()` of external URLs or unrecognized packages',
+              '- [ ] No network requests at config evaluation time',
+              '',
+              '**`.github/workflows/`**',
+              '- [ ] No steps that read secrets and send them to external services',
+              '- [ ] Permissions are minimal and explicitly declared',
+            ].join('\n');
+
+            const marker = '## 🔒 Security Review Required';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c =>
+              c.user?.login === 'github-actions[bot]' && c.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/security-guard-report.yml
+++ b/.github/workflows/security-guard-report.yml
@@ -31,6 +31,7 @@ jobs:
             let prNumber, files;
             try {
               prNumber = parseInt(fs.readFileSync('security-guard-meta/pr_number.txt', 'utf8').trim(), 10);
+              if (isNaN(prNumber)) throw new Error('Invalid PR number');
               files = fs.readFileSync('security-guard-meta/changed_files.txt', 'utf8').trim();
             } catch {
               core.info('No security review metadata found — skipping comment');


### PR DESCRIPTION
## Summary

`workflow_run` events only trigger from workflows on the repository's **default branch**. Both report workflows existed only on `v2/test/pipeline`, so they were never triggered.

## Changes

- `.github/workflows/e2e-report.yml`: added (with pagination + path + optional chaining fixes)
- `.github/workflows/security-guard-report.yml`: added (with pagination + path + optional chaining fixes)

## Test Results

- [ ] build passes
- [ ] lint passes
- [ ] tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated E2E test reports that post a status comment to pull requests, summarizing outcomes and updating the comment on reruns.
  * Added automated security review reports that post a pull-request comment with a "Security Review Required" checklist and a list of changed files, updating or creating the comment as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->