### PR TITLE
React 18 SSR compatibility and peerDep bump

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -14,8 +14,25 @@
 
 - **WaveSurfer memory leak on unmount**: `waveformInst.destroy()` was never called due to a stale closure in the cleanup effect (empty deps `[]` captured `elementRefs` as `undefined` at mount time). Fixed by tracking the instance via `useRef` so the cleanup always holds the latest reference.
 
+### SSR / Next.js Compatibility
+
+- **`react` and `react-dom` peerDependencies bumped to `>=18.0.0`**: The library already required React 18 features (`useId`). This formalizes the minimum version. Consumers on React 16/17 should use v1.x.
+- **`useIsomorphicLayoutEffect`**: All `useLayoutEffect` calls that require layout timing replaced with an isomorphic wrapper that falls back to `useEffect` during SSR, eliminating React's server-side warning.
+- **`useLayoutEffect` → `useEffect` downgrade**: 6 call sites across 4 files that did not require layout timing were downgraded to `useEffect` (prop sync, state dispatch patterns).
+- **`'use client'` directive**: Added to the library entry point so Next.js App Router consumers can import directly without a client wrapper file.
+- **SSR-safe `window`/`document` access**: `isBrowser` guard utility added; applied to `useVariableColor` and `useGridTemplate`.
+
+### Accessibility
+
+- **Dropdown `useId` + ARIA attributes**: `Dropdown` now generates a unique `dropdownId` via `useId()` (matching the existing `Drawer` pattern). `DropdownTrigger` gains `aria-expanded` and `aria-controls` attributes. `DropdownContent` receives matching `id`.
+
+### Progress Rendering
+
+- **Conditional rendering**: `WaveformProgress` and `BarProgress` are now conditionally rendered based on `activeUI.progress` instead of rendering both and toggling via CSS. Only the active component is mounted.
+
 ### Breaking Changes
 
+- **`react` and `react-dom` minimum version is now `>=18.0.0`**: Projects using React 16/17 must stay on v1.x.
 - **`SpectrumProvider` renamed to `AudioPlayerRootProvider`**: import name changed
   - Before: `import { AudioPlayer, SpectrumProvider } from "react-modern-audio-player"`
   - After: `import { AudioPlayer, AudioPlayerRootProvider } from "react-modern-audio-player"`

--- a/package/README.md
+++ b/package/README.md
@@ -45,6 +45,31 @@ https://codesandbox.io/s/basic-91y82y?file=/src/App.tsx
 npm install --save react-modern-audio-player
 ```
 
+# **Requirements**
+
+- React **18.0.0** or higher
+- react-dom **18.0.0** or higher
+- styled-components **^5.3.5**
+
+# **Next.js / Server Components**
+
+This library includes the `'use client'` directive and can be imported directly in Next.js App Router without additional wrappers.
+
+```tsx
+// app/page.tsx — works directly, no wrapper needed
+import AudioPlayer from "react-modern-audio-player";
+
+const playList = [
+  { name: "track", writer: "artist", img: "cover.jpg", src: "audio.mp3", id: 1 },
+];
+
+export default function Page() {
+  return <AudioPlayer playList={playList} />;
+}
+```
+
+> For React 16/17 projects, use v1.x of this library.
+
 # **Quick Start**
 
 ```tsx

--- a/package/package.json
+++ b/package/package.json
@@ -33,8 +33,8 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
     "styled-components": "^5.3.5"
   },
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modern-audio-player",
-  "version": "1.4.0-rc.2",
+  "version": "2.0.0-rc.1",
   "author": {
     "name": "LYH",
     "email": "slash9494@naver.com",

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/BarProgress.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/BarProgress.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { useProgress } from "./useProgress";
 import { useProgressKeyDown } from "./useProgressKeyDown";
 
-export const BarProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
+export const BarProgress: FC = () => {
   const { currentTime, duration } = useTimeContext();
 
   const progressRatio = safeRatio(currentTime, duration);
@@ -14,7 +14,7 @@ export const BarProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
   const eventProps = useProgress();
   const handleKeyDown = useProgressKeyDown();
 
-  return isActive ? (
+  return (
     <BarProgressWrapper
       className="bar-progress-wrapper"
       data-testid="progress-bar"
@@ -43,7 +43,7 @@ export const BarProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
         }}
       />
     </BarProgressWrapper>
-  ) : null;
+  );
 };
 
 const BarProgressWrapper = styled.div`

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
@@ -2,35 +2,26 @@ import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useResourceContext } from "@/hooks/context/useResourceContext";
 import { getTimeWithPadStart } from "@/utils/getTime";
 import { FC, useCallback, useEffect, useRef } from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { safeRatio } from "@/utils/safeRatio";
 import { useProgress } from "./useProgress";
 import { useProgressKeyDown } from "./useProgressKeyDown";
 import { useWaveSurfer } from "./useWavesurfer";
 
 const WaveformWrapper = styled.div`
-  ${({ isActive }: { isActive: boolean }) => css`
-    display: flex;
+  display: flex;
+  width: 100%;
+  #rm-waveform {
     width: 100%;
-    #rm-waveform {
-      width: 100%;
-      overflow: hidden;
-      wave {
-        cursor: pointer !important;
-        overflow-x: hidden !important;
-      }
-
-      ${!isActive &&
-      css`
-        height: 0;
-        opacity: 0;
-        pointer-events: none;
-      `}
+    overflow: hidden;
+    wave {
+      cursor: pointer !important;
+      overflow-x: hidden !important;
     }
-  `}
+  }
 `;
 
-export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
+export const WaveformProgress: FC = () => {
   const waveformRef = useRef<HTMLDivElement>(null);
   const { curAudioState } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
@@ -40,7 +31,6 @@ export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
   // apply current time to waveform when progress is active
   useEffect(() => {
     if (
-      !isActive ||
       !elementRefs?.waveformInst ||
       !elementRefs?.audioEl ||
       !curAudioState.isLoadedMetaData ||
@@ -54,7 +44,6 @@ export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
     );
     elementRefs.waveformInst.seekTo(ratio);
   }, [
-    isActive,
     curAudioState.isLoadedMetaData,
     elementRefs?.waveformInst,
     elementRefs?.audioEl,
@@ -73,12 +62,12 @@ export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
   const handleKeyDown = useProgressKeyDown(onSeek);
 
   return (
-    <WaveformWrapper className="waveform-wrapper" isActive={isActive}>
+    <WaveformWrapper className="waveform-wrapper">
       <div
         id="rm-waveform"
         ref={waveformRef}
         role="slider"
-        tabIndex={isActive ? 0 : -1}
+        tabIndex={0}
         aria-label="Seek"
         aria-valuemin={0}
         aria-valuemax={100}

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
@@ -40,7 +40,7 @@ const renderBar = () =>
           value={{ elementRefs: { audioEl: mockAudioEl } }}
         >
           <audioPlayerDispatchContext.Provider value={mockDispatch}>
-            <BarProgress isActive={true} />
+            <BarProgress />
           </audioPlayerDispatchContext.Provider>
         </resourceContext.Provider>
       </playbackContext.Provider>

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/index.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/index.tsx
@@ -13,11 +13,8 @@ export const Progress: FC = () => {
 
   return (
     <ProgressContainer className="progress-container">
-      {activeUI.progress === "waveform" ? (
-        <WaveformProgress />
-      ) : (
-        <BarProgress />
-      )}
+      {activeUI.progress === "waveform" && <WaveformProgress />}
+      {activeUI.progress === "bar" && <BarProgress />}
     </ProgressContainer>
   );
 };

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/index.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/index.tsx
@@ -13,8 +13,11 @@ export const Progress: FC = () => {
 
   return (
     <ProgressContainer className="progress-container">
-      <WaveformProgress isActive={activeUI.progress === "waveform"} />
-      <BarProgress isActive={activeUI.progress !== "waveform"} />
+      {activeUI.progress === "waveform" ? (
+        <WaveformProgress />
+      ) : (
+        <BarProgress />
+      )}
     </ProgressContainer>
   );
 };

--- a/package/src/components/AudioPlayer/Player/usePropsStateEffect.ts
+++ b/package/src/components/AudioPlayer/Player/usePropsStateEffect.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { AudioPlayerProps } from ".";
 import {
@@ -19,7 +19,7 @@ export const usePropsStateEffect = <TInterfacePlacementLength extends number>({
 }: Omit<AudioPlayerProps<TInterfacePlacementLength>, "children">) => {
   const [isMounted, setIsMounted] = useState(false);
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isMounted) return;
     const {
       player: playerPlacement,
@@ -41,13 +41,13 @@ export const usePropsStateEffect = <TInterfacePlacementLength extends number>({
     });
   }, [audioPlayerDispatch, placement]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isMounted || !activeUI) return;
 
     audioPlayerDispatch({ type: "SET_ACTIVE_UI", activeUI });
   }, [activeUI, audioPlayerDispatch]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isMounted || !coverImgsCss) return;
 
     audioPlayerDispatch({ type: "SET_COVER_IMGS_CSS", coverImgsCss });

--- a/package/src/components/AudioPlayer/index.tsx
+++ b/package/src/components/AudioPlayer/index.tsx
@@ -20,6 +20,7 @@ const AudioPlayerWithProviders = <TInterfacePlacementLength extends number>({
     <AudioPlayerProvider {...audioPlayProps}>
       <AudioPlayerRootProvider rootContainerProps={rootContainerProps}>
         <AudioPlayer {...audioPlayProps} />
+        {/* @ts-expect-error styled-components v5 GlobalStyle type incompatible with @types/react@18 */}
         <GlobalStyle />
       </AudioPlayerRootProvider>
     </AudioPlayerProvider>

--- a/package/src/components/Drawer/Drawer.tsx
+++ b/package/src/components/Drawer/Drawer.tsx
@@ -2,8 +2,8 @@ import React, {
   PropsWithChildren,
   useRef,
   FC,
+  useEffect,
   useId,
-  useLayoutEffect,
   useState,
 } from "react";
 import styled from "styled-components";
@@ -35,7 +35,7 @@ const Drawer: FC<PropsWithChildren<DrawerProps>> = ({
     setIsOpen(false);
     onOpenChange && onOpenChange(false);
   });
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isOpenProp !== undefined) {
       setIsOpen(isOpenProp);
     }

--- a/package/src/components/Dropdown/Dropdown.tsx
+++ b/package/src/components/Dropdown/Dropdown.tsx
@@ -60,7 +60,7 @@ const Dropdown: FC<PropsWithChildren<DropdownProps>> = ({
       onOpenChange,
       dropdownId,
     }),
-    [dropdownRef, placement, isOpen, setIsOpen, onOpenChange, dropdownId]
+    [placement, isOpen, onOpenChange, dropdownId]
   );
 
   return (

--- a/package/src/components/Dropdown/Dropdown.tsx
+++ b/package/src/components/Dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import React, {
   FC,
   useEffect,
   useId,
+  useMemo,
   useState,
 } from "react";
 import styled from "styled-components";
@@ -50,17 +51,20 @@ const Dropdown: FC<PropsWithChildren<DropdownProps>> = ({
     }
   }, [isOpenProp]);
 
+  const contextValue = useMemo(
+    () => ({
+      dropdownRef,
+      placement,
+      isOpen,
+      setIsOpen,
+      onOpenChange,
+      dropdownId,
+    }),
+    [dropdownRef, placement, isOpen, setIsOpen, onOpenChange, dropdownId]
+  );
+
   return (
-    <dropdownContext.Provider
-      value={{
-        dropdownRef,
-        placement,
-        isOpen,
-        setIsOpen,
-        onOpenChange,
-        dropdownId,
-      }}
-    >
+    <dropdownContext.Provider value={contextValue}>
       <DropdownContainer
         className="dropdown-container"
         ref={dropdownRef}

--- a/package/src/components/Dropdown/Dropdown.tsx
+++ b/package/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,8 @@ import React, {
   PropsWithChildren,
   useRef,
   FC,
-  useLayoutEffect,
+  useEffect,
+  useId,
   useState,
 } from "react";
 import styled from "styled-components";
@@ -40,8 +41,10 @@ const Dropdown: FC<PropsWithChildren<DropdownProps>> = ({
     clickArea: "root",
   });
 
+  const dropdownId = useId();
+
   useClickOutside(dropdownRef, () => outboundClickActive && setIsOpen(false));
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isOpenProp !== undefined) {
       setIsOpen(isOpenProp);
     }
@@ -49,7 +52,14 @@ const Dropdown: FC<PropsWithChildren<DropdownProps>> = ({
 
   return (
     <dropdownContext.Provider
-      value={{ dropdownRef, placement, isOpen, setIsOpen, onOpenChange }}
+      value={{
+        dropdownRef,
+        placement,
+        isOpen,
+        setIsOpen,
+        onOpenChange,
+        dropdownId,
+      }}
     >
       <DropdownContainer
         className="dropdown-container"

--- a/package/src/components/Dropdown/DropdownContent.tsx
+++ b/package/src/components/Dropdown/DropdownContent.tsx
@@ -28,7 +28,7 @@ export const DropdownContent: FC<PropsWithChildren<DropdownContentProps>> = ({
   isWithAnimation = true,
   ...dropdownContentProps
 }) => {
-  const { dropdownRef, placement, isOpen, setIsOpen } =
+  const { dropdownRef, placement, isOpen, setIsOpen, dropdownId } =
     useNonNullableContext(dropdownContext);
   const [dropdownSize, setDropdownSize] = useState<DropdownSize>();
   const { onClick } = useDropdown({
@@ -53,6 +53,7 @@ export const DropdownContent: FC<PropsWithChildren<DropdownContentProps>> = ({
       dropdownSize ? (
         <DropdownContentContainer
           {...dropdownContentProps}
+          id={dropdownId}
           dropdownSize={dropdownSize}
           placement={placement}
           onClick={onClick}

--- a/package/src/components/Dropdown/DropdownContext.ts
+++ b/package/src/components/Dropdown/DropdownContext.ts
@@ -5,6 +5,7 @@ export interface DropdownContext {
   placement: "top" | "bottom" | "left" | "right";
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onOpenChange?: (isOpen: boolean) => void;
+  dropdownId: string;
 }
 
 export const dropdownContext = createContext<DropdownContext | null>(null);

--- a/package/src/components/Dropdown/DropdownTrigger.tsx
+++ b/package/src/components/Dropdown/DropdownTrigger.tsx
@@ -1,7 +1,18 @@
 import { FC, PropsWithChildren } from "react";
+import { useNonNullableContext } from "@/hooks/useNonNullableContext";
+import { dropdownContext } from "./DropdownContext";
 
 export const DropdownTrigger: FC<PropsWithChildren<unknown>> = ({
   children,
 }) => {
-  return <div className={"dropdown-trigger-wrapper"}>{children}</div>;
+  const { isOpen, dropdownId } = useNonNullableContext(dropdownContext);
+  return (
+    <div
+      className="dropdown-trigger-wrapper"
+      aria-expanded={isOpen}
+      aria-controls={dropdownId}
+    >
+      {children}
+    </div>
+  );
 };

--- a/package/src/components/Dropdown/DropdownTrigger.tsx
+++ b/package/src/components/Dropdown/DropdownTrigger.tsx
@@ -1,16 +1,26 @@
-import { FC, PropsWithChildren } from "react";
+import { FC, KeyboardEvent, PropsWithChildren } from "react";
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { dropdownContext } from "./DropdownContext";
 
-export const DropdownTrigger: FC<PropsWithChildren<unknown>> = ({
-  children,
-}) => {
-  const { isOpen, dropdownId } = useNonNullableContext(dropdownContext);
+export const DropdownTrigger: FC<PropsWithChildren> = ({ children }) => {
+  const { isOpen, setIsOpen, dropdownId } =
+    useNonNullableContext(dropdownContext);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setIsOpen((prev) => !prev);
+    }
+  };
+
   return (
     <div
       className="dropdown-trigger-wrapper"
+      role="button"
+      tabIndex={0}
       aria-expanded={isOpen}
       aria-controls={dropdownId}
+      onKeyDown={handleKeyDown}
     >
       {children}
     </div>

--- a/package/src/components/Provider/AudioPlayerRootProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerRootProvider.tsx
@@ -3,7 +3,7 @@ import {
   FC,
   HTMLAttributes,
   PropsWithChildren,
-  useLayoutEffect,
+  useEffect,
   useState,
 } from "react";
 import { useUIContext } from "@/hooks/context/useUIContext";
@@ -18,7 +18,7 @@ export const AudioPlayerRootProvider: FC<
   const { playerPlacement: contextPlayerPlacement } = useUIContext();
   const [placementState, setPlacementState] =
     useState<Pick<CSSProperties, "top" | "right" | "bottom" | "left">>();
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (contextPlayerPlacement) {
       const placementValidation = () => {
         const base = {

--- a/package/src/hooks/useGridTemplate.ts
+++ b/package/src/hooks/useGridTemplate.ts
@@ -3,6 +3,7 @@ import {
   defaultInterfacePlacement,
   InterfacePlacement,
 } from "@/components/AudioPlayer/Context";
+import { isBrowser } from "@/utils/ssr";
 import { useCallback, useState } from "react";
 
 export const useGridTemplate = (
@@ -119,7 +120,7 @@ export const useGridTemplate = (
         return cols.trimStart();
       });
 
-      const maxWidth = window ? window.innerWidth - 100 : 1500;
+      const maxWidth = isBrowser ? window.innerWidth - 100 : 1500;
       const gridColumns = new Array(maxRow).fill("").map((_, rowIdx) => {
         let cols = "";
         for (let i = 0; i < maxCol; i++) {

--- a/package/src/hooks/useVariableColor.ts
+++ b/package/src/hooks/useVariableColor.ts
@@ -1,4 +1,5 @@
-import { useLayoutEffect, useRef, useCallback } from "react";
+import { useRef, useCallback } from "react";
+import { isBrowser, useIsomorphicLayoutEffect } from "@/utils/ssr";
 
 export type VariableColors<T extends string> = Record<T, string>;
 
@@ -22,7 +23,8 @@ export const useVariableColor = <Keys extends string>(
     colorsRef.current = parsedColors;
   }, [variableColors]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
+    if (!isBrowser) return;
     readColors();
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     mediaQuery.addEventListener("change", readColors);

--- a/package/src/hooks/useVariableColor.ts
+++ b/package/src/hooks/useVariableColor.ts
@@ -1,5 +1,5 @@
 import { useRef, useCallback } from "react";
-import { isBrowser, useIsomorphicLayoutEffect } from "@/utils/ssr";
+import { useIsomorphicLayoutEffect } from "@/utils/ssr";
 
 export type VariableColors<T extends string> = Record<T, string>;
 
@@ -24,7 +24,6 @@ export const useVariableColor = <Keys extends string>(
   }, [variableColors]);
 
   useIsomorphicLayoutEffect(() => {
-    if (!isBrowser) return;
     readColors();
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     mediaQuery.addEventListener("change", readColors);

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import AudioPlayerWithProviders from "./components/AudioPlayer";
 import { CustomComponent } from "./components/AudioPlayer/Interface/CustomComponent";
 

--- a/package/src/ui/CssTransition.tsx
+++ b/package/src/ui/CssTransition.tsx
@@ -1,10 +1,5 @@
-import React, {
-  cloneElement,
-  FC,
-  PropsWithChildren,
-  useLayoutEffect,
-  useState,
-} from "react";
+import React, { cloneElement, FC, PropsWithChildren, useState } from "react";
+import { useIsomorphicLayoutEffect } from "@/utils/ssr";
 import { keyframes } from "styled-components";
 
 export const appearanceIn = keyframes({
@@ -56,7 +51,7 @@ export const CssTransition: FC<PropsWithChildren<CssTransitionProps>> = ({
   const [classNames, setClassNames] = useState("");
   const [renderable, setRenderable] = useState(false);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const statusClassName = visible ? "enter" : "leave";
     const time = visible ? enterTime : leaveTime;
     if (visible && !renderable) {

--- a/package/src/utils/ssr.ts
+++ b/package/src/utils/ssr.ts
@@ -1,0 +1,9 @@
+import { useEffect, useLayoutEffect } from "react";
+
+/** true when running in a browser environment */
+export const isBrowser = typeof window !== "undefined";
+
+/** useLayoutEffect that falls back to useEffect during SSR */
+export const useIsomorphicLayoutEffect = isBrowser
+  ? useLayoutEffect
+  : useEffect;

--- a/package/src/utils/ssr.ts
+++ b/package/src/utils/ssr.ts
@@ -4,6 +4,6 @@ import { useEffect, useLayoutEffect } from "react";
 export const isBrowser = typeof window !== "undefined";
 
 /** useLayoutEffect that falls back to useEffect during SSR */
-export const useIsomorphicLayoutEffect = isBrowser
+export const useIsomorphicLayoutEffect: typeof useLayoutEffect = isBrowser
   ? useLayoutEffect
   : useEffect;


### PR DESCRIPTION
## Summary

- Bump peerDependencies to `react/react-dom >= 18` (formalizes de facto requirement — `useId` was already in use)
- Add `src/utils/ssr.ts` utility with `isBrowser` guard and `useIsomorphicLayoutEffect`
- Replace `useLayoutEffect` with `useIsomorphicLayoutEffect` in 2 files where layout timing is required (useVariableColor, CssTransition)
- Downgrade `useLayoutEffect` → `useEffect` in 4 files where layout timing was unnecessary (prop sync, state dispatch)
- Add `'use client'` directive to entry point for Next.js App Router compatibility
- Add `useId` + ARIA attributes to Dropdown (accessibility parity with Drawer)
- Switch Progress to conditional rendering instead of CSS toggle
- Bump version to `2.0.0-rc.1`
- Fix `GlobalStyle` type error for styled-components v5 + @types/react@18

## Test plan

- [x] All 199 tests pass
- [x] Type check passes (`yarn typeCheck`)
- [x] Lint + prettier pass (pre-commit hook)
- [x] Pre-push hook passes (unit + integration + typeCheck)
- [ ] Manual: verify player works in dev (`yarn dev`)
- [ ] Manual: verify Dropdown keyboard navigation (Tab → Enter/Space)

false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Minimum React/ReactDOM requirement raised to 18.0.0+; package major version updated.

* **New Features**
  * Official compatibility with Next.js App Router for client-side usage.

* **Accessibility**
  * Dropdown trigger/content now expose stable IDs and matching ARIA attributes.

* **Improvements**
  * Better SSR/runtime compatibility and safer browser checks; progress UIs mount conditionally for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->