### PR TITLE
♻️ refactor(v2): phase 2 — reducer purity, playback flatten, audio attr passthrough

### DIFF
--- a/conventions/code-naming.md
+++ b/conventions/code-naming.md
@@ -97,6 +97,62 @@ Use the same word for the same domain concept throughout the codebase.
 
 ---
 
+## Comments
+
+Comments are a **last resort**, not a default. Before writing any comment — inline, block, or JSDoc — ask: *can this be expressed through naming or code structure instead?* If yes, rewrite the code and drop the comment.
+
+### Rules
+
+1. **Prefer naming over comments.**
+   - Extract intermediate values into named variables (`isFeedbackFromTimeUpdate`, `isTrackDurationReady`, `clampedRatio`).
+   - Extract multi-step logic into named helper functions.
+   - Rename ambiguous identifiers before explaining them.
+2. **Prefer control flow over comments.**
+   - Early-return named guards instead of commenting on conditional blocks.
+   - Split a branching body into labeled constants rather than annotating each branch.
+3. **Only comment when no amount of renaming or restructuring can convey the intent.** Valid cases:
+   - **Non-obvious *why***: the reason for a decision that the code itself cannot show (historical incidents, upstream bugs, external contracts, race conditions that only manifest at runtime).
+   - **Cross-file coupling**: invariants enforced elsewhere that a reader of this file cannot see.
+   - **TODO / FIXME** with a concrete follow-up or ticket reference.
+4. **Remove comments that restate the code.** `// increment counter` above `counter++` is noise.
+5. **Remove comments that name identifiers the code already names.** If a block comment says "volume effect" above a `useEffect`, hoist that phrase into a named variable or a JSDoc on a named function instead — or drop it entirely when the hook body reads obviously.
+6. **Long comments are a smell.** 3+ lines of comment to explain a function body means the function is under-named or under-decomposed. Refactor first.
+
+### Anti-patterns vs. preferred form
+
+```ts
+// BAD — comment restates the check
+// Skip if the delta is below the timeupdate tick threshold to avoid
+// feeding back our own onTimeUpdate dispatches into another seek.
+if (Math.abs(audioEl.currentTime - playbackCurrentTime) <= 0.25) return;
+
+// GOOD — predicate name carries the reason
+const seekDeltaSec = Math.abs(audioEl.currentTime - playbackCurrentTime);
+const isFeedbackFromTimeUpdate = seekDeltaSec <= SEEK_SYNC_THRESHOLD_SEC;
+if (isFeedbackFromTimeUpdate) return;
+```
+
+```ts
+// BAD — label comment above a hook
+// volume effect
+useEffect(() => { ... }, [volume]);
+
+// GOOD — no label needed; effect body self-explains with named values
+useEffect(() => {
+  if (!audioEl || playbackVolume == null) return;
+  audioEl.volume = playbackVolume;
+}, [audioEl, playbackVolume]);
+```
+
+```ts
+// ACCEPTABLE — non-obvious *why* that code cannot show
+// wavesurfer wraps the same <audio> element via the MediaElement backend
+// (useWavesurfer.ts), so reading audioEl.currentTime covers both modes.
+const currentTime = elementRefs?.audioEl?.currentTime ?? 0;
+```
+
+---
+
 ## Anti-Patterns
 
 ```ts

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -70,6 +70,8 @@
 
 - **CSS class names prefixed with `rmap-`**: All internal CSS class names now use the `rmap-` prefix (e.g., `btn-wrapper` → `rmap-ctrl-btn-wrapper`). If you targeted internal class names for custom styling, update your selectors. CSS custom properties (`--rm-audio-player-*`) are unchanged.
 
+- **`rm-audio-player-provider` class renamed to `rmap-player-provider`**: Consumers who target this class in their own stylesheets or tests must update selectors. The CSS custom properties (`--rm-audio-player-*`) are unchanged.
+
 ### Bug Fixes
 
 - **Theme color switching**: system dark/light theme changes now correctly update progress bar, volume slider, shadow, and waveform colors

--- a/package/README.md
+++ b/package/README.md
@@ -183,7 +183,7 @@ interface AudioPlayerProps {
 | `customIcons`        | [CustomIcons](#customicons)               | undefined                                                                                                       |
 | `coverImgsCss`       | [CoverImgsCss](#coverimgscss)             | undefined                                                                                                       |
 | `placement`          | [Placement](#placement)                   | playListPlacement : "bottom" </br>interfacePlacement :[DefaultInterfacePlacement](#default-interface-placement) |
-| `rootContainerProps` | [RootContainerProps](#rootcontainerprops) | width: 100%<br/>position: 'static'<br/>className: rm-audio-player-provider                                      |
+| `rootContainerProps` | [RootContainerProps](#rootcontainerprops) | width: 100%<br/>position: 'static'<br/>className: rmap-player-provider                                          |
 | `colorScheme`        | `"light" \| "dark"`                       | undefined (follows OS `prefers-color-scheme`)                                                                   |
 
 ## PlayList
@@ -328,21 +328,21 @@ const defaultInterfacePlacement = {
 
 ## RootContainerProps
 
-`rootContainerProps` accepts any standard `HTMLAttributes<HTMLDivElement>` (e.g. `className`, `style`, `data-*`). The root container always has the class `rm-audio-player-provider` applied automatically.
+`rootContainerProps` accepts any standard `HTMLAttributes<HTMLDivElement>` (e.g. `className`, `style`, `data-*`). The root container always has the class `rmap-player-provider` applied automatically.
 
-> ⚠️ Setting the native CSS `color-scheme` property via `rootContainerProps={{ style: { colorScheme: "dark" } }}` will **not** toggle the player's theme. The library's theme is driven by the `prefers-color-scheme` media query and the `[data-theme]` attribute selector — use the top-level [`colorScheme`](#theme-mode--dark-mode-) prop instead.
+> ⚠️ Setting the native CSS `color-scheme` property via `rootContainerProps={{ style: { colorScheme: "dark" } }}` will **not** toggle the player's theme. The library's theme is driven by the `prefers-color-scheme` media query and the `[data-theme]` attribute selector — use the top-level [`colorScheme`](#theme-mode--dark-mode) prop instead.
 
 # Override Style
 
 ## Theme mode ( dark-mode )
 
 > Dark mode is driven by `system-theme` (`prefers-color-scheme: dark`) by default.
-> To force a specific theme regardless of OS preference, pass the top-level `colorScheme="light" | "dark"` prop on `<AudioPlayer>` — this applies a `data-theme` attribute on `.rm-audio-player-provider` which overrides the media query.
-> You can override any color by redefining the CSS variables below on `.rm-audio-player-provider`.
+> To force a specific theme regardless of OS preference, pass the top-level `colorScheme="light" | "dark"` prop on `<AudioPlayer>` — this applies a `data-theme` attribute on `.rmap-player-provider` which overrides the media query.
+> You can override any color by redefining the CSS variables below on `.rmap-player-provider`.
 
 ```css
 @media (prefers-color-scheme: dark) {
-  .rm-audio-player-provider {
+  .rmap-player-provider {
     --rm-audio-player-interface-container: #1e1e1e;
     /* override other variables as needed */
   }
@@ -357,12 +357,12 @@ const defaultInterfacePlacement = {
 
 ### root ClassName
 
-- rm-audio-player-provider
+- rmap-player-provider
 
 ### color variables
 
 ```css
-.rm-audio-player-provider {
+.rmap-player-provider {
   --rm-audio-player-text-color: #2c2c2c;
   --rm-audio-player-shadow: 0 0 0;
   --rm-audio-player-interface-container: #f5f5f5;

--- a/package/preview/e2e/App.tsx
+++ b/package/preview/e2e/App.tsx
@@ -53,7 +53,7 @@ function parseTestConfig(): TestConfig {
 }
 
 function App() {
-  const config = parseTestConfig();
+  const [config] = useState<TestConfig>(() => parseTestConfig());
 
   // When the test does NOT supply its own activeUI, default to "all on +
   // bar progress" so legacy specs (e.g. ui-placement) that only configure
@@ -116,6 +116,7 @@ function App() {
        */}
       <button
         type="button"
+        data-testid="rmap-toggle-progress-type"
         onClick={() =>
           setProgressType((prev) => (prev === "waveform" ? "bar" : "waveform"))
         }

--- a/package/preview/e2e/main.tsx
+++ b/package/preview/e2e/main.tsx
@@ -2,7 +2,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 
 const container = document.getElementById("root");
-const root = createRoot(container as HTMLElement, {
+if (!container) throw new Error("Root element #root not found");
+const root = createRoot(container, {
   // eslint-disable-next-line no-console
   onRecoverableError: (error) => console.error("recovering", error),
 });

--- a/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
+++ b/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
@@ -1,0 +1,255 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FC, ReactNode, SyntheticEvent } from "react";
+import { useAudio } from "../useAudio";
+import { RepeatType } from "@/components/AudioPlayer/Context/StateContext";
+import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContext";
+import { timeContext } from "@/components/AudioPlayer/Context/TimeContext";
+import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
+import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
+
+// useAudio's seek sync effect mirrors playbackCurrentTime back into the
+// underlying <audio> element and waveform cursor. These tests fence the
+// guards (NaN/0/Infinity duration, missing waveform), the threshold skip
+// that prevents onTimeUpdate feedback, and the [0, 1] clamp.
+
+const TRACK_DURATION_SEC = 180;
+const SEEK_SYNC_THRESHOLD_SEC = 0.25;
+
+const makePlaybackValue = (repeatType: RepeatType = "ALL") => ({
+  isPlaying: false,
+  volume: 0.5,
+  muted: false,
+  repeatType,
+  isLoadedMetaData: true,
+  audioResetKey: 0,
+});
+
+interface HarnessOptions {
+  playbackCurrentTime: number;
+  audioElCurrentTime: number;
+  audioElDuration: number;
+  waveformInst?: {
+    seekTo: (ratio: number) => void;
+    getCurrentTime: () => number;
+  };
+  repeatType?: RepeatType;
+  dispatch?: ReturnType<typeof vi.fn>;
+}
+
+const makeAudioEl = (currentTime: number, duration: number) => {
+  const audioEl = document.createElement("audio");
+  Object.defineProperty(audioEl, "currentTime", {
+    value: currentTime,
+    writable: true,
+  });
+  Object.defineProperty(audioEl, "duration", {
+    value: duration,
+    writable: true,
+  });
+  return audioEl;
+};
+
+const renderUseAudio = (options: HarnessOptions) => {
+  const audioEl = makeAudioEl(
+    options.audioElCurrentTime,
+    options.audioElDuration
+  );
+  const dispatch = options.dispatch ?? vi.fn();
+  const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+    <timeContext.Provider
+      value={{
+        currentTime: options.playbackCurrentTime,
+        duration: TRACK_DURATION_SEC,
+      }}
+    >
+      <playbackContext.Provider value={makePlaybackValue(options.repeatType)}>
+        <resourceContext.Provider
+          value={{
+            elementRefs: {
+              audioEl,
+              waveformInst: options.waveformInst as never,
+            },
+          }}
+        >
+          <audioPlayerDispatchContext.Provider value={dispatch}>
+            {children}
+          </audioPlayerDispatchContext.Provider>
+        </resourceContext.Provider>
+      </playbackContext.Provider>
+    </timeContext.Provider>
+  );
+  const { result } = renderHook(() => useAudio(), { wrapper });
+  return { audioEl, dispatch, result };
+};
+
+describe("useAudio seek sync effect", () => {
+  let waveformSeekTo: ReturnType<typeof vi.fn>;
+  let waveformInst: HarnessOptions["waveformInst"];
+
+  beforeEach(() => {
+    waveformSeekTo = vi.fn();
+    waveformInst = {
+      seekTo: waveformSeekTo,
+      getCurrentTime: vi.fn(() => 0),
+    };
+  });
+
+  it("writes audioEl.currentTime and waveform cursor when delta exceeds the feedback threshold", () => {
+    const { audioEl } = renderUseAudio({
+      playbackCurrentTime: 60,
+      audioElCurrentTime: 10,
+      audioElDuration: TRACK_DURATION_SEC,
+      waveformInst,
+    });
+
+    expect(audioEl.currentTime).toBe(60);
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+    expect(waveformSeekTo).toHaveBeenCalledWith(60 / TRACK_DURATION_SEC);
+  });
+
+  it("skips both DOM write and waveform cursor when delta is within the feedback threshold", () => {
+    const audioElCurrentTime = 60;
+    const playbackCurrentTime =
+      audioElCurrentTime + SEEK_SYNC_THRESHOLD_SEC / 2;
+    const { audioEl } = renderUseAudio({
+      playbackCurrentTime,
+      audioElCurrentTime,
+      audioElDuration: TRACK_DURATION_SEC,
+      waveformInst,
+    });
+
+    expect(audioEl.currentTime).toBe(audioElCurrentTime);
+    expect(waveformSeekTo).not.toHaveBeenCalled();
+  });
+
+  it("still writes audioEl.currentTime even when waveformInst is absent", () => {
+    const { audioEl } = renderUseAudio({
+      playbackCurrentTime: 60,
+      audioElCurrentTime: 10,
+      audioElDuration: TRACK_DURATION_SEC,
+      waveformInst: undefined,
+    });
+
+    expect(audioEl.currentTime).toBe(60);
+  });
+
+  it("does not call waveform.seekTo when audioEl.duration is NaN (metadata not loaded)", () => {
+    renderUseAudio({
+      playbackCurrentTime: 60,
+      audioElCurrentTime: 10,
+      audioElDuration: NaN,
+      waveformInst,
+    });
+
+    expect(waveformSeekTo).not.toHaveBeenCalled();
+  });
+
+  it("does not call waveform.seekTo when audioEl.duration is 0", () => {
+    renderUseAudio({
+      playbackCurrentTime: 60,
+      audioElCurrentTime: 10,
+      audioElDuration: 0,
+      waveformInst,
+    });
+
+    expect(waveformSeekTo).not.toHaveBeenCalled();
+  });
+
+  it("does not call waveform.seekTo when audioEl.duration is Infinity (live stream)", () => {
+    renderUseAudio({
+      playbackCurrentTime: 60,
+      audioElCurrentTime: 10,
+      audioElDuration: Infinity,
+      waveformInst,
+    });
+
+    expect(waveformSeekTo).not.toHaveBeenCalled();
+  });
+
+  it("clamps the ratio to 1 when playbackCurrentTime exceeds audioEl.duration (track-change race)", () => {
+    renderUseAudio({
+      playbackCurrentTime: 240,
+      audioElCurrentTime: 0,
+      audioElDuration: 120,
+      waveformInst,
+    });
+
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+    expect(waveformSeekTo).toHaveBeenCalledWith(1);
+  });
+
+  it("clamps the ratio to 0 when playbackCurrentTime is negative", () => {
+    renderUseAudio({
+      playbackCurrentTime: -5,
+      audioElCurrentTime: 60,
+      audioElDuration: TRACK_DURATION_SEC,
+      waveformInst,
+    });
+
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+    expect(waveformSeekTo).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("useAudio onEnded handler", () => {
+  beforeEach(() => {
+    window.HTMLMediaElement.prototype.play = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    window.HTMLMediaElement.prototype.pause = vi.fn();
+  });
+
+  it("repeat ONE — flushSync-dispatches currentTime=0 so the seek sync effect resets audioEl before play() runs", () => {
+    // Regression: previously onEnded wrote audioEl.currentTime = 0 directly
+    // without dispatching state. A pending onTimeUpdate dispatch (queued at
+    // ~end) would render after the reset and the seek sync effect treated
+    // the stale state as the "desired" position, jumping the freshly-
+    // restarted track straight back to its end. The fix routes the reset
+    // through dispatch under flushSync so React commits the seek sync
+    // effect ahead of the play() call. Static-context harness can only
+    // observe the dispatch contract; the DOM-write half is exercised by
+    // the seek sync effect describe block above.
+    const dispatch = vi.fn();
+    const playSpy = window.HTMLMediaElement.prototype.play as ReturnType<
+      typeof vi.fn
+    >;
+    const { result } = renderUseAudio({
+      playbackCurrentTime: 178,
+      audioElCurrentTime: 178,
+      audioElDuration: TRACK_DURATION_SEC,
+      repeatType: "ONE",
+      dispatch,
+    });
+
+    const playCallsBefore = playSpy.mock.calls.length;
+
+    act(() => {
+      result.current.onEnded?.({} as SyntheticEvent<HTMLAudioElement, Event>);
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "SET_AUDIO_STATE",
+      audioState: { currentTime: 0 },
+    });
+    expect(playSpy.mock.calls.length).toBeGreaterThan(playCallsBefore);
+  });
+
+  it("non-ONE repeat — dispatches NEXT_AUDIO instead of touching DOM directly", () => {
+    const dispatch = vi.fn();
+    const { audioEl, result } = renderUseAudio({
+      playbackCurrentTime: 178,
+      audioElCurrentTime: 178,
+      audioElDuration: TRACK_DURATION_SEC,
+      repeatType: "ALL",
+      dispatch,
+    });
+
+    act(() => {
+      result.current.onEnded?.({} as SyntheticEvent<HTMLAudioElement, Event>);
+    });
+
+    expect(audioEl.currentTime).toBe(178);
+    expect(dispatch).toHaveBeenCalledWith({ type: "NEXT_AUDIO" });
+  });
+});

--- a/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
+++ b/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
@@ -192,6 +192,41 @@ describe("useAudio seek sync effect", () => {
   });
 });
 
+describe("useAudio play effect — initial mount", () => {
+  beforeEach(() => {
+    window.HTMLMediaElement.prototype.play = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    window.HTMLMediaElement.prototype.pause = vi.fn();
+  });
+
+  it("calls audioEl.play() when isPlaying=true on initial mount with an audioEl present", () => {
+    const audioEl = makeAudioEl(0, TRACK_DURATION_SEC);
+    const dispatch = vi.fn();
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <timeContext.Provider
+        value={{ currentTime: 0, duration: TRACK_DURATION_SEC }}
+      >
+        <playbackContext.Provider
+          value={{ ...makePlaybackValue(), isPlaying: true }}
+        >
+          <resourceContext.Provider
+            value={{
+              elementRefs: { audioEl, waveformInst: undefined as never },
+            }}
+          >
+            <audioPlayerDispatchContext.Provider value={dispatch}>
+              {children}
+            </audioPlayerDispatchContext.Provider>
+          </resourceContext.Provider>
+        </playbackContext.Provider>
+      </timeContext.Provider>
+    );
+    renderHook(() => useAudio(), { wrapper });
+    expect(audioEl.play).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("useAudio onEnded handler", () => {
   beforeEach(() => {
     window.HTMLMediaElement.prototype.play = vi

--- a/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
+++ b/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, render, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { FC, ReactNode, SyntheticEvent } from "react";
 import { useAudio } from "../useAudio";
@@ -8,13 +8,13 @@ import { timeContext } from "@/components/AudioPlayer/Context/TimeContext";
 import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
 
-// useAudio's seek sync effect mirrors playbackCurrentTime back into the
-// underlying <audio> element and waveform cursor. These tests fence the
-// guards (NaN/0/Infinity duration, missing waveform), the threshold skip
-// that prevents onTimeUpdate feedback, and the [0, 1] clamp.
+// useAudio's seek sync effect only writes audioEl.currentTime (and the
+// waveform cursor) when a SEEK dispatch has incremented seekRequestKey.
+// Ordinary onTimeUpdate echoes, which only change playbackCurrentTime,
+// must never reach the DOM write path — otherwise a slow React commit
+// could resurrect a stale state and seek the live audio backwards.
 
 const TRACK_DURATION_SEC = 180;
-const SEEK_SYNC_THRESHOLD_SEC = 0.25;
 
 const makePlaybackValue = (repeatType: RepeatType = "ALL") => ({
   isPlaying: false,
@@ -29,6 +29,7 @@ interface HarnessOptions {
   playbackCurrentTime: number;
   audioElCurrentTime: number;
   audioElDuration: number;
+  seekRequestKey?: number;
   waveformInst?: {
     seekTo: (ratio: number) => void;
     getCurrentTime: () => number;
@@ -61,6 +62,7 @@ const renderUseAudio = (options: HarnessOptions) => {
       value={{
         currentTime: options.playbackCurrentTime,
         duration: TRACK_DURATION_SEC,
+        seekRequestKey: options.seekRequestKey ?? 0,
       }}
     >
       <playbackContext.Provider value={makePlaybackValue(options.repeatType)}>
@@ -95,11 +97,12 @@ describe("useAudio seek sync effect", () => {
     };
   });
 
-  it("writes audioEl.currentTime and waveform cursor when delta exceeds the feedback threshold", () => {
+  it("applies playbackCurrentTime to audioEl and waveform when seekRequestKey is non-zero on mount", () => {
     const { audioEl } = renderUseAudio({
       playbackCurrentTime: 60,
       audioElCurrentTime: 10,
       audioElDuration: TRACK_DURATION_SEC,
+      seekRequestKey: 1,
       waveformInst,
     });
 
@@ -108,26 +111,29 @@ describe("useAudio seek sync effect", () => {
     expect(waveformSeekTo).toHaveBeenCalledWith(60 / TRACK_DURATION_SEC);
   });
 
-  it("skips both DOM write and waveform cursor when delta is within the feedback threshold", () => {
-    const audioElCurrentTime = 60;
-    const playbackCurrentTime =
-      audioElCurrentTime + SEEK_SYNC_THRESHOLD_SEC / 2;
+  it("does NOT write audioEl.currentTime when seekRequestKey is 0, even when playbackCurrentTime is far from DOM (stale onTimeUpdate echo scenario)", () => {
+    // Regression for the old 0.25s-delta heuristic: a state commit that
+    // arrives after audio has already progressed ahead in real playback
+    // would look like a "user seek" under the old logic and drag audio
+    // backwards. The new keyed approach requires a SEEK dispatch to apply.
     const { audioEl } = renderUseAudio({
-      playbackCurrentTime,
-      audioElCurrentTime,
+      playbackCurrentTime: 10,
+      audioElCurrentTime: 60,
       audioElDuration: TRACK_DURATION_SEC,
+      seekRequestKey: 0,
       waveformInst,
     });
 
-    expect(audioEl.currentTime).toBe(audioElCurrentTime);
+    expect(audioEl.currentTime).toBe(60);
     expect(waveformSeekTo).not.toHaveBeenCalled();
   });
 
-  it("still writes audioEl.currentTime even when waveformInst is absent", () => {
+  it("still writes audioEl.currentTime when waveformInst is absent", () => {
     const { audioEl } = renderUseAudio({
       playbackCurrentTime: 60,
       audioElCurrentTime: 10,
       audioElDuration: TRACK_DURATION_SEC,
+      seekRequestKey: 1,
       waveformInst: undefined,
     });
 
@@ -139,6 +145,7 @@ describe("useAudio seek sync effect", () => {
       playbackCurrentTime: 60,
       audioElCurrentTime: 10,
       audioElDuration: NaN,
+      seekRequestKey: 1,
       waveformInst,
     });
 
@@ -150,6 +157,7 @@ describe("useAudio seek sync effect", () => {
       playbackCurrentTime: 60,
       audioElCurrentTime: 10,
       audioElDuration: 0,
+      seekRequestKey: 1,
       waveformInst,
     });
 
@@ -161,6 +169,7 @@ describe("useAudio seek sync effect", () => {
       playbackCurrentTime: 60,
       audioElCurrentTime: 10,
       audioElDuration: Infinity,
+      seekRequestKey: 1,
       waveformInst,
     });
 
@@ -172,6 +181,7 @@ describe("useAudio seek sync effect", () => {
       playbackCurrentTime: 240,
       audioElCurrentTime: 0,
       audioElDuration: 120,
+      seekRequestKey: 1,
       waveformInst,
     });
 
@@ -184,11 +194,124 @@ describe("useAudio seek sync effect", () => {
       playbackCurrentTime: -5,
       audioElCurrentTime: 60,
       audioElDuration: TRACK_DURATION_SEC,
+      seekRequestKey: 1,
       waveformInst,
     });
 
     expect(waveformSeekTo).toHaveBeenCalledTimes(1);
     expect(waveformSeekTo).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("useAudio seek sync effect — rerender behavior", () => {
+  it("does not re-apply after an onTimeUpdate echo with the same seekRequestKey", () => {
+    const waveformSeekTo = vi.fn();
+    const waveformInst = {
+      seekTo: waveformSeekTo,
+      getCurrentTime: vi.fn(() => 0),
+    };
+    const audioEl = makeAudioEl(10, TRACK_DURATION_SEC);
+
+    const HookHost: FC = () => {
+      useAudio();
+      return null;
+    };
+
+    const Harness: FC<{
+      playbackCurrentTime: number;
+      seekRequestKey: number;
+    }> = ({ playbackCurrentTime, seekRequestKey }) => (
+      <timeContext.Provider
+        value={{
+          currentTime: playbackCurrentTime,
+          duration: TRACK_DURATION_SEC,
+          seekRequestKey,
+        }}
+      >
+        <playbackContext.Provider value={makePlaybackValue()}>
+          <resourceContext.Provider
+            value={{
+              elementRefs: {
+                audioEl,
+                waveformInst: waveformInst as never,
+              },
+            }}
+          >
+            <audioPlayerDispatchContext.Provider value={vi.fn()}>
+              <HookHost />
+            </audioPlayerDispatchContext.Provider>
+          </resourceContext.Provider>
+        </playbackContext.Provider>
+      </timeContext.Provider>
+    );
+
+    const { rerender } = render(
+      <Harness playbackCurrentTime={60} seekRequestKey={1} />
+    );
+    expect(audioEl.currentTime).toBe(60);
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+
+    // Simulate audio advancing past the seek target during normal
+    // playback. The onTimeUpdate echo rerenders with the advanced
+    // playbackCurrentTime but the same seekRequestKey.
+    audioEl.currentTime = 61.5;
+    rerender(<Harness playbackCurrentTime={61.5} seekRequestKey={1} />);
+
+    expect(audioEl.currentTime).toBe(61.5);
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-applies when seekRequestKey increments (new SEEK dispatch)", () => {
+    const waveformSeekTo = vi.fn();
+    const waveformInst = {
+      seekTo: waveformSeekTo,
+      getCurrentTime: vi.fn(() => 0),
+    };
+    const audioEl = makeAudioEl(10, TRACK_DURATION_SEC);
+
+    const HookHost: FC = () => {
+      useAudio();
+      return null;
+    };
+
+    const Harness: FC<{
+      playbackCurrentTime: number;
+      seekRequestKey: number;
+    }> = ({ playbackCurrentTime, seekRequestKey }) => (
+      <timeContext.Provider
+        value={{
+          currentTime: playbackCurrentTime,
+          duration: TRACK_DURATION_SEC,
+          seekRequestKey,
+        }}
+      >
+        <playbackContext.Provider value={makePlaybackValue()}>
+          <resourceContext.Provider
+            value={{
+              elementRefs: {
+                audioEl,
+                waveformInst: waveformInst as never,
+              },
+            }}
+          >
+            <audioPlayerDispatchContext.Provider value={vi.fn()}>
+              <HookHost />
+            </audioPlayerDispatchContext.Provider>
+          </resourceContext.Provider>
+        </playbackContext.Provider>
+      </timeContext.Provider>
+    );
+
+    const { rerender } = render(
+      <Harness playbackCurrentTime={60} seekRequestKey={1} />
+    );
+    expect(audioEl.currentTime).toBe(60);
+    expect(waveformSeekTo).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness playbackCurrentTime={90} seekRequestKey={2} />);
+    expect(audioEl.currentTime).toBe(90);
+    expect(waveformSeekTo).toHaveBeenCalledTimes(2);
+    expect(waveformSeekTo).toHaveBeenLastCalledWith(90 / TRACK_DURATION_SEC);
   });
 });
 
@@ -205,7 +328,11 @@ describe("useAudio play effect — initial mount", () => {
     const dispatch = vi.fn();
     const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
       <timeContext.Provider
-        value={{ currentTime: 0, duration: TRACK_DURATION_SEC }}
+        value={{
+          currentTime: 0,
+          duration: TRACK_DURATION_SEC,
+          seekRequestKey: 0,
+        }}
       >
         <playbackContext.Provider
           value={{ ...makePlaybackValue(), isPlaying: true }}
@@ -235,16 +362,12 @@ describe("useAudio onEnded handler", () => {
     window.HTMLMediaElement.prototype.pause = vi.fn();
   });
 
-  it("repeat ONE — flushSync-dispatches currentTime=0 so the seek sync effect resets audioEl before play() runs", () => {
-    // Regression: previously onEnded wrote audioEl.currentTime = 0 directly
-    // without dispatching state. A pending onTimeUpdate dispatch (queued at
-    // ~end) would render after the reset and the seek sync effect treated
-    // the stale state as the "desired" position, jumping the freshly-
-    // restarted track straight back to its end. The fix routes the reset
-    // through dispatch under flushSync so React commits the seek sync
-    // effect ahead of the play() call. Static-context harness can only
-    // observe the dispatch contract; the DOM-write half is exercised by
-    // the seek sync effect describe block above.
+  it("repeat ONE — dispatches SEEK { time: 0 } under flushSync and then calls play()", () => {
+    // Regression for the jump-to-end bug: the reset must travel through
+    // SEEK so the seek sync effect applies audioEl.currentTime = 0 before
+    // play() runs. The static-context harness only observes the dispatch
+    // contract; the DOM-write half is exercised by the seek sync effect
+    // describe block above.
     const dispatch = vi.fn();
     const playSpy = window.HTMLMediaElement.prototype.play as ReturnType<
       typeof vi.fn
@@ -263,10 +386,7 @@ describe("useAudio onEnded handler", () => {
       result.current.onEnded?.({} as SyntheticEvent<HTMLAudioElement, Event>);
     });
 
-    expect(dispatch).toHaveBeenCalledWith({
-      type: "SET_AUDIO_STATE",
-      audioState: { currentTime: 0 },
-    });
+    expect(dispatch).toHaveBeenCalledWith({ type: "SEEK", time: 0 });
     expect(playSpy.mock.calls.length).toBeGreaterThan(playCallsBefore);
   });
 

--- a/package/src/components/AudioPlayer/Audio/index.tsx
+++ b/package/src/components/AudioPlayer/Audio/index.tsx
@@ -12,7 +12,7 @@ export const Audio: FC<{
   audioRef?: React.MutableRefObject<HTMLAudioElement>;
 }> = ({ audioRef: propsAudioRef }) => {
   const audioRef = useRef<HTMLAudioElement>(null);
-  const { isPlaying, muted } = usePlaybackContext();
+  const { muted } = usePlaybackContext();
   const { curPlayId, playList } = useTrackContext();
   const nativeAudioAttrs = useAudioAttrsContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
@@ -40,7 +40,6 @@ export const Audio: FC<{
     <audio
       id="rm-audio-player-audio"
       {...nativeAudioAttrs}
-      autoPlay={isPlaying}
       muted={muted}
       ref={audioRef}
       src={curPlayedAudioData?.src}

--- a/package/src/components/AudioPlayer/Audio/index.tsx
+++ b/package/src/components/AudioPlayer/Audio/index.tsx
@@ -1,6 +1,5 @@
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
-import { AudioNativeProps } from "@/components/AudioPlayer/Context/StateContext";
 import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useTrackContext } from "@/hooks/context/useTrackContext";
 import React, { FC, useEffect, useRef } from "react";
@@ -12,27 +11,13 @@ export const Audio: FC<{
   audioRef?: React.MutableRefObject<HTMLAudioElement>;
 }> = ({ audioRef: propsAudioRef }) => {
   const audioRef = useRef<HTMLAudioElement>(null);
-  const { curAudioState } = usePlaybackContext();
+  const { isPlaying, muted } = usePlaybackContext();
   const { curPlayId, playList } = useTrackContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
   const curPlayedAudioData = playList.find(
     (audioData) => audioData.id === curPlayId
   );
-  // Drop the React-side fields that are not valid HTML <audio> attributes
-  // before spreading the rest onto the element. Destructuring makes the
-  // intent obvious and removes the opaque `Object.entries → filter →
-  // fromEntries` sequence.
-  const {
-    isPlaying: _isPlaying,
-    repeatType: _repeatType,
-    isLoadedMetaData: _isLoadedMetaData,
-    ...audioNativeStates
-  } = curAudioState as AudioNativeProps & {
-    isPlaying?: unknown;
-    repeatType?: unknown;
-    isLoadedMetaData?: unknown;
-  };
 
   const useAudioEventProps = useAudio();
 
@@ -52,11 +37,11 @@ export const Audio: FC<{
   return (
     <audio
       id="rm-audio-player-audio"
-      autoPlay={curAudioState.isPlaying}
+      autoPlay={isPlaying}
+      muted={muted}
       ref={audioRef}
       src={curPlayedAudioData?.src}
       {...useAudioEventProps}
-      {...audioNativeStates}
     ></audio>
   );
 };

--- a/package/src/components/AudioPlayer/Audio/index.tsx
+++ b/package/src/components/AudioPlayer/Audio/index.tsx
@@ -1,9 +1,9 @@
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
-import { audioAttrsContext } from "@/components/AudioPlayer/Context/AudioAttrsContext";
+import { useAudioAttrsContext } from "@/hooks/context/useAudioAttrsContext";
 import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useTrackContext } from "@/hooks/context/useTrackContext";
-import React, { FC, useContext, useEffect, useRef } from "react";
+import React, { FC, useEffect, useRef } from "react";
 import { useAudio } from "./useAudio";
 
 // TODO : optimize large audio files
@@ -14,7 +14,7 @@ export const Audio: FC<{
   const audioRef = useRef<HTMLAudioElement>(null);
   const { isPlaying, muted } = usePlaybackContext();
   const { curPlayId, playList } = useTrackContext();
-  const nativeAudioAttrs = useContext(audioAttrsContext) ?? {};
+  const nativeAudioAttrs = useAudioAttrsContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
   const curPlayedAudioData = playList.find(

--- a/package/src/components/AudioPlayer/Audio/index.tsx
+++ b/package/src/components/AudioPlayer/Audio/index.tsx
@@ -1,8 +1,9 @@
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
+import { audioAttrsContext } from "@/components/AudioPlayer/Context/AudioAttrsContext";
 import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useTrackContext } from "@/hooks/context/useTrackContext";
-import React, { FC, useEffect, useRef } from "react";
+import React, { FC, useContext, useEffect, useRef } from "react";
 import { useAudio } from "./useAudio";
 
 // TODO : optimize large audio files
@@ -13,6 +14,7 @@ export const Audio: FC<{
   const audioRef = useRef<HTMLAudioElement>(null);
   const { isPlaying, muted } = usePlaybackContext();
   const { curPlayId, playList } = useTrackContext();
+  const nativeAudioAttrs = useContext(audioAttrsContext) ?? {};
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
   const curPlayedAudioData = playList.find(
@@ -37,6 +39,7 @@ export const Audio: FC<{
   return (
     <audio
       id="rm-audio-player-audio"
+      {...nativeAudioAttrs}
       autoPlay={isPlaying}
       muted={muted}
       ref={audioRef}

--- a/package/src/components/AudioPlayer/Audio/useAudio.ts
+++ b/package/src/components/AudioPlayer/Audio/useAudio.ts
@@ -12,8 +12,6 @@ import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useResourceContext } from "@/hooks/context/useResourceContext";
 import { useTimeContext } from "@/hooks/context/useTimeContext";
 
-const SEEK_SYNC_THRESHOLD_SEC = 0.25;
-
 export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
   const {
     isPlaying,
@@ -21,7 +19,7 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     repeatType,
     audioResetKey,
   } = usePlaybackContext();
-  const { currentTime: playbackCurrentTime } = useTimeContext();
+  const { currentTime: playbackCurrentTime, seekRequestKey } = useTimeContext();
   const { elementRefs } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
@@ -44,10 +42,7 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
       // = 0 before play() runs, so the restart starts from 0 and a pending
       // onTimeUpdate at ~end cannot resurrect the stale position.
       flushSync(() => {
-        audioPlayerDispatch({
-          type: "SET_AUDIO_STATE",
-          audioState: { currentTime: 0 },
-        });
+        audioPlayerDispatch({ type: "SEEK", time: 0 });
       });
       elementRefs.audioEl.play();
       return;
@@ -97,13 +92,18 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     elementRefs.audioEl.volume = playbackVolume;
   }, [elementRefs?.audioEl, playbackVolume]);
 
+  // Apply seeks explicitly signaled by a SEEK dispatch. Keyed on
+  // seekRequestKey so ordinary onTimeUpdate echoes (which change
+  // playbackCurrentTime) never reach the DOM write path and cannot
+  // pull audio backwards when React commits land later than the
+  // browser's real playback position.
+  const lastAppliedSeekKeyRef = useRef(0);
   useEffect(() => {
+    if (seekRequestKey === lastAppliedSeekKeyRef.current) return;
+    lastAppliedSeekKeyRef.current = seekRequestKey;
+
     const audioEl = elementRefs?.audioEl;
     if (!audioEl || playbackCurrentTime == null) return;
-
-    const seekDeltaSec = Math.abs(audioEl.currentTime - playbackCurrentTime);
-    const isFeedbackFromTimeUpdate = seekDeltaSec <= SEEK_SYNC_THRESHOLD_SEC;
-    if (isFeedbackFromTimeUpdate) return;
 
     audioEl.currentTime = playbackCurrentTime;
 
@@ -116,7 +116,12 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     const rawRatio = playbackCurrentTime / trackDuration;
     const clampedRatio = Math.min(1, Math.max(0, rawRatio));
     waveform.seekTo(clampedRatio);
-  }, [playbackCurrentTime, elementRefs?.audioEl, elementRefs?.waveformInst]);
+  }, [
+    seekRequestKey,
+    playbackCurrentTime,
+    elementRefs?.audioEl,
+    elementRefs?.waveformInst,
+  ]);
 
   return {
     onTimeUpdate,

--- a/package/src/components/AudioPlayer/Audio/useAudio.ts
+++ b/package/src/components/AudioPlayer/Audio/useAudio.ts
@@ -6,6 +6,7 @@ import {
   useEffect,
   useRef,
 } from "react";
+import { flushSync } from "react-dom";
 import { audioPlayerDispatchContext } from "../Context";
 import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useResourceContext } from "@/hooks/context/useResourceContext";
@@ -14,8 +15,13 @@ import { useTimeContext } from "@/hooks/context/useTimeContext";
 const SEEK_SYNC_THRESHOLD_SEC = 0.25;
 
 export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
-  const { isPlaying, volume, repeatType, audioResetKey } = usePlaybackContext();
-  const { currentTime } = useTimeContext();
+  const {
+    isPlaying,
+    volume: playbackVolume,
+    repeatType,
+    audioResetKey,
+  } = usePlaybackContext();
+  const { currentTime: playbackCurrentTime } = useTimeContext();
   const { elementRefs } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
@@ -34,7 +40,15 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
   const onEnded = useCallback(() => {
     if (!elementRefs?.audioEl) return;
     if (repeatType === "ONE") {
-      elementRefs.audioEl.currentTime = 0;
+      // flushSync forces the seek sync effect to write audioEl.currentTime
+      // = 0 before play() runs, so the restart starts from 0 and a pending
+      // onTimeUpdate at ~end cannot resurrect the stale position.
+      flushSync(() => {
+        audioPlayerDispatch({
+          type: "SET_AUDIO_STATE",
+          audioState: { currentTime: 0 },
+        });
+      });
       elementRefs.audioEl.play();
       return;
     }
@@ -52,19 +66,18 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     [audioPlayerDispatch]
   );
 
-  const hasMountedRef = useRef(false);
-
-  /** audio reset — triggered by NEXT_AUDIO / PREV_AUDIO via audioResetKey */
+  // Skip the very first audioResetKey effect run so the freshly-mounted
+  // <audio> element keeps any consumer-set initial currentTime.
+  const hasSkippedInitialResetRef = useRef(false);
   useEffect(() => {
     if (!elementRefs?.audioEl) return;
-    if (!hasMountedRef.current) {
-      hasMountedRef.current = true;
+    if (!hasSkippedInitialResetRef.current) {
+      hasSkippedInitialResetRef.current = true;
       return;
     }
     elementRefs.audioEl.currentTime = 0;
   }, [audioResetKey, elementRefs?.audioEl]);
 
-  /** play */
   useEffect(() => {
     if (!elementRefs?.audioEl) return;
     if (isPlaying) {
@@ -79,28 +92,31 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     }
   }, [elementRefs?.audioEl, isPlaying, audioPlayerDispatch]);
 
-  /** volume */
   useEffect(() => {
-    if (!elementRefs?.audioEl || volume == null) return;
-    elementRefs.audioEl.volume = volume;
-  }, [elementRefs?.audioEl, volume]);
+    if (!elementRefs?.audioEl || playbackVolume == null) return;
+    elementRefs.audioEl.volume = playbackVolume;
+  }, [elementRefs?.audioEl, playbackVolume]);
 
-  /** seek sync — react to external seek() dispatches by writing the
-   * target time back to the underlying media element (and waveform cursor
-   * when wavesurfer is active). Skipped when the delta is below the
-   * timeupdate-tick threshold to avoid feeding back our own onTimeUpdate
-   * dispatches into another seek. */
   useEffect(() => {
     const audioEl = elementRefs?.audioEl;
-    if (!audioEl || currentTime == null) return;
-    if (Math.abs(audioEl.currentTime - currentTime) <= SEEK_SYNC_THRESHOLD_SEC)
-      return;
-    audioEl.currentTime = currentTime;
+    if (!audioEl || playbackCurrentTime == null) return;
+
+    const seekDeltaSec = Math.abs(audioEl.currentTime - playbackCurrentTime);
+    const isFeedbackFromTimeUpdate = seekDeltaSec <= SEEK_SYNC_THRESHOLD_SEC;
+    if (isFeedbackFromTimeUpdate) return;
+
+    audioEl.currentTime = playbackCurrentTime;
+
     const waveform = elementRefs?.waveformInst;
-    if (waveform && audioEl.duration) {
-      waveform.seekTo(currentTime / audioEl.duration);
-    }
-  }, [currentTime, elementRefs?.audioEl, elementRefs?.waveformInst]);
+    const trackDuration = audioEl.duration;
+    const isTrackDurationReady =
+      Number.isFinite(trackDuration) && trackDuration > 0;
+    if (!waveform || !isTrackDurationReady) return;
+
+    const rawRatio = playbackCurrentTime / trackDuration;
+    const clampedRatio = Math.min(1, Math.max(0, rawRatio));
+    waveform.seekTo(clampedRatio);
+  }, [playbackCurrentTime, elementRefs?.audioEl, elementRefs?.waveformInst]);
 
   return {
     onTimeUpdate,

--- a/package/src/components/AudioPlayer/Audio/useAudio.ts
+++ b/package/src/components/AudioPlayer/Audio/useAudio.ts
@@ -9,9 +9,13 @@ import {
 import { audioPlayerDispatchContext } from "../Context";
 import { usePlaybackContext } from "@/hooks/context/usePlaybackContext";
 import { useResourceContext } from "@/hooks/context/useResourceContext";
+import { useTimeContext } from "@/hooks/context/useTimeContext";
+
+const SEEK_SYNC_THRESHOLD_SEC = 0.25;
 
 export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
-  const { curAudioState, audioResetKey } = usePlaybackContext();
+  const { isPlaying, volume, repeatType, audioResetKey } = usePlaybackContext();
+  const { currentTime } = useTimeContext();
   const { elementRefs } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
@@ -29,13 +33,13 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
 
   const onEnded = useCallback(() => {
     if (!elementRefs?.audioEl) return;
-    if (curAudioState.repeatType === "ONE") {
+    if (repeatType === "ONE") {
       elementRefs.audioEl.currentTime = 0;
       elementRefs.audioEl.play();
       return;
     }
     audioPlayerDispatch({ type: "NEXT_AUDIO" });
-  }, [audioPlayerDispatch, curAudioState.repeatType, elementRefs?.audioEl]);
+  }, [audioPlayerDispatch, repeatType, elementRefs?.audioEl]);
 
   const onLoadedMetadata = useCallback(
     (e: SyntheticEvent<HTMLAudioElement, Event>) => {
@@ -63,7 +67,7 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
   /** play */
   useEffect(() => {
     if (!elementRefs?.audioEl) return;
-    if (curAudioState.isPlaying) {
+    if (isPlaying) {
       void elementRefs.audioEl.play().catch(() => {
         audioPlayerDispatch({
           type: "SET_AUDIO_STATE",
@@ -73,13 +77,30 @@ export const useAudio = (): HTMLAttributes<HTMLAudioElement> => {
     } else {
       elementRefs.audioEl.pause();
     }
-  }, [elementRefs?.audioEl, curAudioState.isPlaying, audioPlayerDispatch]);
+  }, [elementRefs?.audioEl, isPlaying, audioPlayerDispatch]);
 
   /** volume */
   useEffect(() => {
-    if (!elementRefs?.audioEl || curAudioState.volume == null) return;
-    elementRefs.audioEl.volume = curAudioState.volume;
-  }, [elementRefs?.audioEl, curAudioState.volume]);
+    if (!elementRefs?.audioEl || volume == null) return;
+    elementRefs.audioEl.volume = volume;
+  }, [elementRefs?.audioEl, volume]);
+
+  /** seek sync — react to external seek() dispatches by writing the
+   * target time back to the underlying media element (and waveform cursor
+   * when wavesurfer is active). Skipped when the delta is below the
+   * timeupdate-tick threshold to avoid feeding back our own onTimeUpdate
+   * dispatches into another seek. */
+  useEffect(() => {
+    const audioEl = elementRefs?.audioEl;
+    if (!audioEl || currentTime == null) return;
+    if (Math.abs(audioEl.currentTime - currentTime) <= SEEK_SYNC_THRESHOLD_SEC)
+      return;
+    audioEl.currentTime = currentTime;
+    const waveform = elementRefs?.waveformInst;
+    if (waveform && audioEl.duration) {
+      waveform.seekTo(currentTime / audioEl.duration);
+    }
+  }, [currentTime, elementRefs?.audioEl, elementRefs?.waveformInst]);
 
   return {
     onTimeUpdate,

--- a/package/src/components/AudioPlayer/Context/AudioAttrsContext.ts
+++ b/package/src/components/AudioPlayer/Context/AudioAttrsContext.ts
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+import { AudioNativeProps } from "./StateContext";
+
+/**
+ * Native HTML <audio> attributes that the consumer passes through
+ * `audioInitialState`. Held in its own context so the <Audio> element can
+ * spread them onto the underlying media element without forcing every
+ * playback consumer to re-render whenever a primitive playback field
+ * (isPlaying / volume / muted / repeatType / isLoadedMetaData) changes.
+ *
+ * Sourced directly from the `audioInitialState` prop, not from reducer
+ * state, so the value object is stable across per-tick `SET_AUDIO_STATE`
+ * dispatches and only changes when the consumer hands in a new
+ * `audioInitialState` reference.
+ */
+export type AudioAttrsContext = Omit<
+  AudioNativeProps,
+  "volume" | "muted" | "src"
+>;
+
+export const audioAttrsContext = createContext<AudioAttrsContext | null>(null);

--- a/package/src/components/AudioPlayer/Context/PlaybackContext.ts
+++ b/package/src/components/AudioPlayer/Context/PlaybackContext.ts
@@ -2,9 +2,9 @@ import { createContext } from "react";
 import { RepeatType } from "./StateContext";
 
 export interface PlaybackContext {
-  isPlaying: boolean | undefined;
-  volume: number | undefined;
-  muted: boolean | undefined;
+  isPlaying: boolean;
+  volume: number;
+  muted: boolean;
   repeatType: RepeatType;
   isLoadedMetaData: boolean | undefined;
   audioResetKey: number;

--- a/package/src/components/AudioPlayer/Context/PlaybackContext.ts
+++ b/package/src/components/AudioPlayer/Context/PlaybackContext.ts
@@ -1,8 +1,12 @@
 import { createContext } from "react";
-import { AudioState } from "./StateContext";
+import { RepeatType } from "./StateContext";
 
 export interface PlaybackContext {
-  curAudioState: AudioState;
+  isPlaying: boolean | undefined;
+  volume: number | undefined;
+  muted: boolean | undefined;
+  repeatType: RepeatType;
+  isLoadedMetaData: boolean | undefined;
   audioResetKey: number;
 }
 

--- a/package/src/components/AudioPlayer/Context/StateContext/index.ts
+++ b/package/src/components/AudioPlayer/Context/StateContext/index.ts
@@ -27,6 +27,7 @@ export interface AudioPlayerStateContext {
   customIcons?: CustomIcons;
   coverImgsCss?: CoverImgsCss;
   audioResetKey: number;
+  seekRequestKey: number;
 }
 
 export type InitialStates = Partial<AudioState> & {

--- a/package/src/components/AudioPlayer/Context/TimeContext.ts
+++ b/package/src/components/AudioPlayer/Context/TimeContext.ts
@@ -3,6 +3,7 @@ import { createContext } from "react";
 export interface TimeContext {
   currentTime: number;
   duration: number;
+  seekRequestKey: number;
 }
 
 export const timeContext = createContext<TimeContext | null>(null);

--- a/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
+++ b/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
@@ -25,9 +25,6 @@ const makeBaseState = (): AudioPlayerStateContext => ({
   },
 });
 
-// ─────────────────────────────────────────
-// NEXT_AUDIO
-// ─────────────────────────────────────────
 describe("NEXT_AUDIO", () => {
   it("advances to next track (normal)", () => {
     const state = { ...makeBaseState(), curIdx: 0, curPlayId: 1 };
@@ -110,9 +107,6 @@ describe("NEXT_AUDIO", () => {
   });
 });
 
-// ─────────────────────────────────────────
-// PREV_AUDIO
-// ─────────────────────────────────────────
 describe("PREV_AUDIO", () => {
   it("goes to previous track (normal)", () => {
     const state = { ...makeBaseState(), curIdx: 1, curPlayId: 2 };
@@ -221,9 +215,6 @@ describe("PREV_AUDIO", () => {
   });
 });
 
-// ─────────────────────────────────────────
-// CHANGE_PLAYING_STATE
-// ─────────────────────────────────────────
 describe("CHANGE_PLAYING_STATE", () => {
   it("toggles isPlaying from false to true", () => {
     const base = makeBaseState();
@@ -267,9 +258,6 @@ describe("CHANGE_PLAYING_STATE", () => {
   });
 });
 
-// ─────────────────────────────────────────
-// SET_REPEAT_TYPE
-// ─────────────────────────────────────────
 describe("SET_REPEAT_TYPE", () => {
   it.each([
     ["ALL" as const],
@@ -285,9 +273,6 @@ describe("SET_REPEAT_TYPE", () => {
   });
 });
 
-// ─────────────────────────────────────────
-// UPDATE_PLAY_LIST
-// ─────────────────────────────────────────
 describe("UPDATE_PLAY_LIST", () => {
   it("updates playlist and recalculates curIdx", () => {
     const newPlayList = [
@@ -317,9 +302,6 @@ describe("UPDATE_PLAY_LIST", () => {
   });
 });
 
-// ─────────────────────────────────────────
-// SET_VOLUME / SET_MUTED
-// ─────────────────────────────────────────
 describe("SET_VOLUME", () => {
   it("updates volume in curAudioState", () => {
     const next = audioPlayerReducer(makeBaseState(), {

--- a/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
+++ b/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
@@ -116,29 +116,32 @@ describe("NEXT_AUDIO", () => {
 describe("PREV_AUDIO", () => {
   it("goes to previous track (normal)", () => {
     const state = { ...makeBaseState(), curIdx: 1, curPlayId: 2 };
-    const next = audioPlayerReducer(state, { type: "PREV_AUDIO" });
+    const next = audioPlayerReducer(state, {
+      type: "PREV_AUDIO",
+      currentTime: 0,
+    });
     expect(next.curIdx).toBe(0);
     expect(next.curPlayId).toBe(1);
   });
 
   it("wraps around to last track when at first (repeatType ALL)", () => {
     const state = { ...makeBaseState(), curIdx: 0, curPlayId: 1 };
-    const next = audioPlayerReducer(state, { type: "PREV_AUDIO" });
+    const next = audioPlayerReducer(state, {
+      type: "PREV_AUDIO",
+      currentTime: 0,
+    });
     expect(next.curIdx).toBe(2);
     expect(next.curPlayId).toBe(3);
   });
 
-  it("resets current track (stays) when currentTime > 1", () => {
-    const audioEl = document.createElement("audio");
-    audioEl.currentTime = 5;
-    const base = makeBaseState();
-    const state = {
-      ...base,
-      curIdx: 1,
-      curPlayId: 2,
-      elementRefs: { audioEl },
-    };
-    const next = audioPlayerReducer(state, { type: "PREV_AUDIO" });
+  it("resets current track (stays) when payload currentTime > 1", () => {
+    // Reducer is now pure: rewind decision uses the action payload only,
+    // so the test no longer needs to construct a mock <audio> element.
+    const state = { ...makeBaseState(), curIdx: 1, curPlayId: 2 };
+    const next = audioPlayerReducer(state, {
+      type: "PREV_AUDIO",
+      currentTime: 5,
+    });
     expect(next.curIdx).toBe(1);
     expect(next.curPlayId).toBe(2);
     expect(next.audioResetKey).toBe(state.audioResetKey + 1);
@@ -155,7 +158,10 @@ describe("PREV_AUDIO", () => {
         repeatType: "NONE" as const,
       },
     };
-    const next = audioPlayerReducer(state, { type: "PREV_AUDIO" });
+    const next = audioPlayerReducer(state, {
+      type: "PREV_AUDIO",
+      currentTime: 0,
+    });
     expect(next.curIdx).toBe(0);
     expect(next.audioResetKey).toBe(state.audioResetKey + 1);
   });
@@ -173,7 +179,7 @@ describe("PREV_AUDIO", () => {
     };
     // SHUFFLE must never return the current index
     const nexts = Array.from({ length: 50 }, () =>
-      audioPlayerReducer(state, { type: "PREV_AUDIO" })
+      audioPlayerReducer(state, { type: "PREV_AUDIO", currentTime: 0 })
     );
     expect(nexts.every((s) => s.curIdx !== 1)).toBe(true);
     expect(
@@ -202,7 +208,10 @@ describe("PREV_AUDIO", () => {
         audioResetKey: 0,
         curAudioState: { ...singleTrackState.curAudioState, repeatType: mode },
       };
-      const next = audioPlayerReducer(state, { type: "PREV_AUDIO" });
+      const next = audioPlayerReducer(state, {
+        type: "PREV_AUDIO",
+        currentTime: 0,
+      });
       expect(next.curIdx).toBe(0);
       expect(next.curPlayId).toBe(1);
       expect(next.curAudioState.isLoadedMetaData).toBe(true);

--- a/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
+++ b/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
@@ -20,6 +20,7 @@ const makeBaseState = (): AudioPlayerStateContext => ({
   activeUI: {},
   playListPlacement: "bottom",
   audioResetKey: 0,
+  seekRequestKey: 0,
   elementRefs: {
     audioEl: document.createElement("audio"),
   },
@@ -361,5 +362,32 @@ describe("SET_MUTED", () => {
     };
     const next = audioPlayerReducer(state, { type: "SET_MUTED", muted: false });
     expect(next.curAudioState.muted).toBe(false);
+  });
+});
+
+describe("SEEK", () => {
+  it("sets curAudioState.currentTime to the payload time", () => {
+    const next = audioPlayerReducer(makeBaseState(), {
+      type: "SEEK",
+      time: 42,
+    });
+    expect(next.curAudioState.currentTime).toBe(42);
+  });
+
+  it("increments seekRequestKey so useAudio's keyed effect fires", () => {
+    const state = { ...makeBaseState(), seekRequestKey: 3 };
+    const next = audioPlayerReducer(state, { type: "SEEK", time: 10 });
+    expect(next.seekRequestKey).toBe(4);
+  });
+
+  it("increments on each SEEK even when the target time is the same", () => {
+    // Effect is keyed on seekRequestKey identity, so repeat seeks to the
+    // same position must still trigger it (e.g. user drags slider and
+    // releases at the starting value).
+    let state = { ...makeBaseState(), seekRequestKey: 0 };
+    state = audioPlayerReducer(state, { type: "SEEK", time: 30 });
+    expect(state.seekRequestKey).toBe(1);
+    state = audioPlayerReducer(state, { type: "SEEK", time: 30 });
+    expect(state.seekRequestKey).toBe(2);
   });
 });

--- a/package/src/components/AudioPlayer/Context/dispatchContext.ts
+++ b/package/src/components/AudioPlayer/Context/dispatchContext.ts
@@ -18,7 +18,7 @@ export type AudioContextAction<
   TInterfacePlacementLength extends number = typeof defaultInterfacePlacementMaxLength
 > =
   | { type: "NEXT_AUDIO" }
-  | { type: "PREV_AUDIO" }
+  | { type: "PREV_AUDIO"; currentTime: number }
   | { type: "UPDATE_PLAY_LIST"; playList: PlayList }
   | { type: "SET_AUDIO_STATE"; audioState: Partial<AudioState> }
   | {

--- a/package/src/components/AudioPlayer/Context/dispatchContext.ts
+++ b/package/src/components/AudioPlayer/Context/dispatchContext.ts
@@ -19,6 +19,7 @@ export type AudioContextAction<
 > =
   | { type: "NEXT_AUDIO" }
   | { type: "PREV_AUDIO"; currentTime: number }
+  | { type: "SEEK"; time: number }
   | { type: "UPDATE_PLAY_LIST"; playList: PlayList }
   | { type: "SET_AUDIO_STATE"; audioState: Partial<AudioState> }
   | {

--- a/package/src/components/AudioPlayer/Context/index.ts
+++ b/package/src/components/AudioPlayer/Context/index.ts
@@ -2,6 +2,7 @@ export * from "./StateContext";
 export * from "./dispatchContext";
 export * from "./reducer";
 export * from "./PlaybackContext";
+export * from "./AudioAttrsContext";
 export * from "./TrackContext";
 export * from "./UIContext";
 export * from "./ResourceContext";

--- a/package/src/components/AudioPlayer/Context/reducer.ts
+++ b/package/src/components/AudioPlayer/Context/reducer.ts
@@ -155,6 +155,12 @@ export const audioPlayerReducer = (
         ...state,
         curAudioState: { ...state.curAudioState, ...action.audioState },
       };
+    case "SEEK":
+      return {
+        ...state,
+        seekRequestKey: state.seekRequestKey + 1,
+        curAudioState: { ...state.curAudioState, currentTime: action.time },
+      };
     case "SET_INITIAL_STATES":
       return {
         ...state,

--- a/package/src/components/AudioPlayer/Context/reducer.ts
+++ b/package/src/components/AudioPlayer/Context/reducer.ts
@@ -3,6 +3,8 @@ import { getRandomNumber } from "@/utils/getRandomNumber";
 import { AudioContextAction } from "./dispatchContext";
 import { AudioPlayerStateContext } from "./StateContext";
 
+const PREV_RESET_THRESHOLD_SEC = 1;
+
 const getRandomIdx = (curIdx: number, minNumber: number, maxNumber: number) => {
   // Guard: when the playable range collapses to a single index (e.g. a
   // playlist with one track) the loop below would spin forever waiting
@@ -78,13 +80,14 @@ export const audioPlayerReducer = (
       // (a) flip isLoadedMetaData=false on the only track and disable the
       // progress bar (ALL/no-mode path) or (b) re-dispatch the same index
       // for SHUFFLE without resetting audio. Treat it as a single concern.
+      const isSingleTrackPlaylist = state.playList.length <= 1;
+      const shouldRewindToStart = action.currentTime > PREV_RESET_THRESHOLD_SEC;
+      const isFirstTrackNoRepeat =
+        state.curAudioState.repeatType === "NONE" && state.curIdx === 0;
       if (
-        state.playList.length <= 1 ||
-        (state.elementRefs?.audioEl &&
-          state.elementRefs?.audioEl.currentTime > 1) ||
-        (state.elementRefs?.waveformInst &&
-          state.elementRefs?.waveformInst.getCurrentTime() > 1) ||
-        (state.curAudioState.repeatType === "NONE" && state.curIdx === 0)
+        isSingleTrackPlaylist ||
+        shouldRewindToStart ||
+        isFirstTrackNoRepeat
       ) {
         return {
           ...state,

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PlayBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PlayBtn.tsx
@@ -9,7 +9,7 @@ import { MdPauseCircleFilled, MdPlayCircleFilled } from "@/components/icons";
 import { Icon } from "../Icon";
 
 export const PlayBtn: FC = memo(function PlayBtn() {
-  const { curAudioState } = usePlaybackContext();
+  const { isPlaying } = usePlaybackContext();
   const { customIcons } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
@@ -19,12 +19,12 @@ export const PlayBtn: FC = memo(function PlayBtn() {
   return (
     <StyledBtn
       type="button"
-      aria-label={curAudioState.isPlaying ? "Pause" : "Play"}
+      aria-label={isPlaying ? "Pause" : "Play"}
       onClick={changePlayState}
       className="rmap-play-btn"
       data-testid="play-btn"
     >
-      {curAudioState.isPlaying ? (
+      {isPlaying ? (
         <Icon
           render={<MdPauseCircleFilled />}
           customIcon={customIcons?.pause}

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
@@ -22,10 +22,12 @@ export const PrevNnextBtn: FC<PrevNnextBtnProps> = memo(function PrevNnextBtn({
       audioPlayerDispatch({ type: "NEXT_AUDIO" });
     }
     if (type === "prev") {
-      const currentTime =
-        elementRefs?.waveformInst?.getCurrentTime() ??
-        elementRefs?.audioEl?.currentTime ??
-        0;
+      // wavesurfer is configured with `backend: "MediaElement"` and wraps
+      // the same `<audio>` element (useWavesurfer.ts), so
+      // waveformInst.getCurrentTime() and audioEl.currentTime always
+      // return identical values. Reading audioEl directly is sufficient —
+      // the legacy reducer used to OR both refs but that branch was dead.
+      const currentTime = elementRefs?.audioEl?.currentTime ?? 0;
       audioPlayerDispatch({ type: "PREV_AUDIO", currentTime });
     }
   };

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/PrevNnextBtn.tsx
@@ -15,14 +15,18 @@ export const PrevNnextBtn: FC<PrevNnextBtnProps> = memo(function PrevNnextBtn({
   type,
   visible,
 }) {
-  const { customIcons } = useResourceContext();
+  const { customIcons, elementRefs } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
   const changeAudio = () => {
     if (type === "next") {
       audioPlayerDispatch({ type: "NEXT_AUDIO" });
     }
     if (type === "prev") {
-      audioPlayerDispatch({ type: "PREV_AUDIO" });
+      const currentTime =
+        elementRefs?.waveformInst?.getCurrentTime() ??
+        elementRefs?.audioEl?.currentTime ??
+        0;
+      audioPlayerDispatch({ type: "PREV_AUDIO", currentTime });
     }
   };
   const PrevNnextIcon = useMemo(() => {

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
@@ -21,8 +21,6 @@ const repeatAriaLabels: Record<RepeatType, string> = {
 };
 
 // Cycle order: ALL → ONE → NONE → SHUFFLE → ALL.
-// A direct lookup makes the cycle declarative and removes the four-case
-// switch + default branch from the click handler.
 const NEXT_REPEAT_TYPE: Record<RepeatType, RepeatType> = {
   ALL: "ONE",
   ONE: "NONE",

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/RepeatTypeBtn.tsx
@@ -31,35 +31,35 @@ const NEXT_REPEAT_TYPE: Record<RepeatType, RepeatType> = {
 };
 
 export const RepeatTypeBtn: FC = memo(function RepeatTypeBtn() {
-  const { curAudioState } = usePlaybackContext();
+  const { repeatType } = usePlaybackContext();
   const { customIcons } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
   const changeRepeatType = () => {
     audioPlayerDispatch({
       type: "SET_REPEAT_TYPE",
-      repeatType: NEXT_REPEAT_TYPE[curAudioState.repeatType],
+      repeatType: NEXT_REPEAT_TYPE[repeatType],
     });
   };
 
   return (
     <StyledBtn
       type="button"
-      aria-label={repeatAriaLabels[curAudioState.repeatType]}
+      aria-label={repeatAriaLabels[repeatType]}
       onClick={changeRepeatType}
       className="rmap-repeat-btn"
       data-testid="repeat-btn"
-      data-repeattype={curAudioState.repeatType}
+      data-repeattype={repeatType}
     >
-      {curAudioState.repeatType === "ALL" && (
+      {repeatType === "ALL" && (
         <Icon render={<TbRepeat />} customIcon={customIcons?.repeatAll} />
       )}
-      {curAudioState.repeatType === "ONE" && (
+      {repeatType === "ONE" && (
         <Icon render={<TbRepeatOnce />} customIcon={customIcons?.repeatOne} />
       )}
-      {curAudioState.repeatType === "NONE" && (
+      {repeatType === "NONE" && (
         <Icon render={<TbRepeatOff />} customIcon={customIcons?.repeatNone} />
       )}
-      {curAudioState.repeatType === "SHUFFLE" && (
+      {repeatType === "SHUFFLE" && (
         <Icon
           render={<TbArrowsShuffle />}
           customIcon={customIcons?.repeatShuffle}

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/VolumeTriggerBtn.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/VolumeTriggerBtn.tsx
@@ -16,32 +16,31 @@ const volumeOpt: SvgIconProps = { size: "100%" };
 
 export const VolumeTriggerBtn = memo(
   forwardRef<HTMLButtonElement>((_, ref) => {
-    const { curAudioState } = usePlaybackContext();
+    const { volume: stateVolume, muted } = usePlaybackContext();
     const { customIcons, elementRefs } = useResourceContext();
     const audioPlayerDispatch = useNonNullableContext(
       audioPlayerDispatchContext
     );
     const changeMuteState = useCallback(
-      () =>
-        audioPlayerDispatch({ type: "SET_MUTED", muted: !curAudioState.muted }),
-      [audioPlayerDispatch, curAudioState.muted]
+      () => audioPlayerDispatch({ type: "SET_MUTED", muted: !muted }),
+      [audioPlayerDispatch, muted]
     );
-    const volume = curAudioState.volume ?? elementRefs?.audioEl?.volume ?? 0;
+    const volume = stateVolume ?? elementRefs?.audioEl?.volume ?? 0;
     const isLowVolume = volume > 0 && volume <= 0.5;
     const isHighVolume = volume > 0.5;
 
     return (
       <StyledBtn
         type="button"
-        aria-label={curAudioState.muted ? "Unmute" : "Mute"}
-        aria-pressed={curAudioState.muted}
+        aria-label={muted ? "Unmute" : "Mute"}
+        aria-pressed={muted}
         onClick={changeMuteState}
         className="rmap-volume-trigger"
         data-testid="volume-trigger-btn"
-        data-muted={String(curAudioState.muted)}
+        data-muted={String(muted)}
         ref={ref}
       >
-        {curAudioState.muted || volume === 0 ? (
+        {muted || volume === 0 ? (
           <Icon
             render={<TbVolume3 {...volumeOpt} />}
             customIcon={customIcons?.volumeMuted}

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/__tests__/PlayBtn.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/__tests__/PlayBtn.a11y.test.tsx
@@ -5,17 +5,14 @@ import { PlayBtn } from "../PlayBtn";
 import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContext";
 import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
-import { AudioState } from "@/components/AudioPlayer/Context/StateContext";
-
 const mockDispatch = vi.fn();
 
 const makePlaybackValue = (isPlaying: boolean) => ({
-  curAudioState: {
-    isPlaying,
-    repeatType: "ALL" as const,
-    muted: false,
-    volume: 0.5,
-  } as AudioState,
+  isPlaying,
+  repeatType: "ALL" as const,
+  muted: false,
+  volume: 0.5,
+  isLoadedMetaData: undefined,
   audioResetKey: 0,
 });
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Button/__tests__/RepeatTypeBtn.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Button/__tests__/RepeatTypeBtn.a11y.test.tsx
@@ -5,20 +5,16 @@ import { RepeatTypeBtn } from "../RepeatTypeBtn";
 import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContext";
 import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
-import {
-  AudioState,
-  RepeatType,
-} from "@/components/AudioPlayer/Context/StateContext";
+import { RepeatType } from "@/components/AudioPlayer/Context/StateContext";
 
 const mockDispatch = vi.fn();
 
 const makePlaybackValue = (repeatType: RepeatType) => ({
-  curAudioState: {
-    isPlaying: false,
-    repeatType,
-    muted: false,
-    volume: 0.5,
-  } as AudioState,
+  isPlaying: false,
+  repeatType,
+  muted: false,
+  volume: 0.5,
+  isLoadedMetaData: undefined,
   audioResetKey: 0,
 });
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
@@ -10,7 +10,7 @@ import "./WaveformProgress.css";
 
 export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
   const waveformRef = useRef<HTMLDivElement>(null);
-  const { curAudioState } = usePlaybackContext();
+  const { isLoadedMetaData, isPlaying } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
 
   useWaveSurfer(waveformRef);
@@ -20,8 +20,8 @@ export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
       !isActive ||
       !elementRefs?.waveformInst ||
       !elementRefs?.audioEl ||
-      !curAudioState.isLoadedMetaData ||
-      curAudioState.isPlaying
+      !isLoadedMetaData ||
+      isPlaying
     )
       return;
 
@@ -32,10 +32,10 @@ export const WaveformProgress: FC<{ isActive: boolean }> = ({ isActive }) => {
     elementRefs.waveformInst.seekTo(ratio);
   }, [
     isActive,
-    curAudioState.isLoadedMetaData,
+    isLoadedMetaData,
     elementRefs?.waveformInst,
     elementRefs?.audioEl,
-    curAudioState.isPlaying,
+    isPlaying,
   ]);
 
   const eventProps = useProgress();

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
@@ -31,7 +31,9 @@ const makePlaybackValue = () => ({
 
 const renderBar = () =>
   render(
-    <timeContext.Provider value={{ currentTime: 0, duration: 180 }}>
+    <timeContext.Provider
+      value={{ currentTime: 0, duration: 180, seekRequestKey: 0 }}
+    >
       <playbackContext.Provider value={makePlaybackValue()}>
         <resourceContext.Provider
           value={{ elementRefs: { audioEl: mockAudioEl } }}

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/BarProgress.a11y.test.tsx
@@ -6,7 +6,6 @@ import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContex
 import { timeContext } from "@/components/AudioPlayer/Context/TimeContext";
 import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
-import { AudioState } from "@/components/AudioPlayer/Context/StateContext";
 
 const mockDispatch = vi.fn();
 const mockAudioEl = document.createElement("audio");
@@ -22,13 +21,11 @@ beforeEach(() => {
 });
 
 const makePlaybackValue = () => ({
-  curAudioState: {
-    isPlaying: false,
-    repeatType: "ALL" as const,
-    muted: false,
-    volume: 0.5,
-    isLoadedMetaData: true,
-  } as AudioState,
+  isPlaying: false,
+  repeatType: "ALL" as const,
+  muted: false,
+  volume: 0.5,
+  isLoadedMetaData: true,
   audioResetKey: 0,
 });
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
@@ -18,7 +18,9 @@ const renderProgress = (progress: "bar" | "waveform") =>
       value={{ activeUI: { progress }, playListPlacement: "bottom" }}
     >
       <trackContext.Provider value={{ playList: [], curPlayId: 1, curIdx: 0 }}>
-        <timeContext.Provider value={{ currentTime: 0, duration: 180 }}>
+        <timeContext.Provider
+          value={{ currentTime: 0, duration: 180, seekRequestKey: 0 }}
+        >
           <playbackContext.Provider
             value={{
               isPlaying: false,

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
@@ -25,7 +25,7 @@ const renderProgress = (progress: "bar" | "waveform") =>
               repeatType: "ALL",
               muted: false,
               volume: 0.5,
-              isLoadedMetaData: undefined,
+              isLoadedMetaData: false,
               audioResetKey: 0,
             }}
           >

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/WaveformProgress.test.tsx
@@ -6,7 +6,6 @@ import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContex
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
 import { uiContext } from "@/components/AudioPlayer/Context/UIContext";
 import { trackContext } from "@/components/AudioPlayer/Context/TrackContext";
-import { AudioState } from "@/components/AudioPlayer/Context/StateContext";
 import { Progress } from "../index";
 
 const mockDispatch = vi.fn();
@@ -22,12 +21,11 @@ const renderProgress = (progress: "bar" | "waveform") =>
         <timeContext.Provider value={{ currentTime: 0, duration: 180 }}>
           <playbackContext.Provider
             value={{
-              curAudioState: {
-                isPlaying: false,
-                repeatType: "ALL",
-                muted: false,
-                volume: 0.5,
-              } as AudioState,
+              isPlaying: false,
+              repeatType: "ALL",
+              muted: false,
+              volume: 0.5,
+              isLoadedMetaData: undefined,
               audioResetKey: 0,
             }}
           >

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useProgress.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useProgress.ts
@@ -10,13 +10,13 @@ import {
 } from "react";
 
 export const useProgress = (): HTMLAttributes<HTMLDivElement> => {
-  const { curAudioState } = usePlaybackContext();
+  const { isLoadedMetaData } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
   const [isTimeChangeActive, setTimeChangeActive] = useState(false);
 
   const moveAudioTime = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
-      if (!elementRefs?.audioEl || !curAudioState?.isLoadedMetaData) return;
+      if (!elementRefs?.audioEl || !isLoadedMetaData) return;
       const { clientX } = e;
       const { clientWidth } = e.currentTarget;
       const boundingRect = e.currentTarget.getBoundingClientRect();
@@ -25,7 +25,7 @@ export const useProgress = (): HTMLAttributes<HTMLDivElement> => {
         safeRatio(curPositionX, clientWidth) * elementRefs.audioEl.duration;
       elementRefs.audioEl.currentTime = curPositionTime;
     },
-    [curAudioState?.isLoadedMetaData, elementRefs?.audioEl]
+    [isLoadedMetaData, elementRefs?.audioEl]
   );
 
   // Block native text selection while user is dragging the progress bar.

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useProgressKeyDown.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useProgressKeyDown.ts
@@ -5,12 +5,12 @@ import React, { useCallback } from "react";
 export const useProgressKeyDown = (
   onSeek?: (newTime: number, duration: number) => void
 ) => {
-  const { curAudioState } = usePlaybackContext();
+  const { isLoadedMetaData } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
 
   return useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (!elementRefs?.audioEl || !curAudioState?.isLoadedMetaData) return;
+      if (!elementRefs?.audioEl || !isLoadedMetaData) return;
       const audio = elementRefs.audioEl;
       let newTime: number | null = null;
       switch (event.key) {
@@ -40,6 +40,6 @@ export const useProgressKeyDown = (
         onSeek?.(newTime, audio.duration);
       }
     },
-    [elementRefs?.audioEl, curAudioState?.isLoadedMetaData, onSeek]
+    [elementRefs?.audioEl, isLoadedMetaData, onSeek]
   );
 };

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -16,7 +16,8 @@ const waveformColors = {
 
 export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
-  const { isPlaying, volume } = usePlaybackContext();
+  const { isPlaying: isPlaybackActive, volume: playbackVolume } =
+    usePlaybackContext();
   const { curPlayId } = useTrackContext();
   const { elementRefs } = useResourceContext();
   const { colorScheme } = useUIContext();
@@ -92,12 +93,12 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     prevPlayIdRef.current = curPlayId;
 
     const savedTime = isTrackChange ? 0 : audioEl.currentTime;
-    const wasPlaying = isPlaying;
+    const wasPlaying = isPlaybackActive;
 
     waveform.load(audioEl);
 
-    if (volume != null) {
-      audioEl.volume = volume;
+    if (playbackVolume != null) {
+      audioEl.volume = playbackVolume;
     }
 
     const onReady = () => {
@@ -115,8 +116,8 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [curPlayId, elementRefs?.audioEl, elementRefs?.waveformInst]);
 
-  // set waveform responsively — trigger drawer 'redraw' on container resize
-  // which internally calls drawBuffer() + drawer.progress() to update all layers
+  // wavesurfer's drawBuffer is not responsive, so we trigger 'redraw' on
+  // container resize via ResizeObserver to keep all canvas layers in sync.
   useEffect(() => {
     if (!waveformRef.current || !elementRefs?.waveformInst) return;
 
@@ -148,15 +149,9 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     [audioPlayerDispatch]
   );
 
-  // Destroy the WaveSurfer instance so the init effect above re-creates it
-  // with the freshly-resolved CSS variable colors. Triggered on either the
-  // OS-level `prefers-color-scheme` media query or the consumer-controlled
-  // `colorScheme` prop change.
-  //
-  // The function is stored on a mutable ref that is rewritten on every
-  // render, so callers (media-query listener, prop-change effect) always
-  // invoke the latest closure — no stale `elementRefs?.waveformInst`,
-  // no listener churn on waveform lifecycle, no exhaustive-deps suppressions.
+  // Latest-closure ref so the media-query and colorScheme listeners below
+  // always destroy the *current* waveformInst without taking it as a dep
+  // (which would churn listener attachment on every waveform lifecycle).
   const destroyInstanceRef = useRef<() => void>();
   destroyInstanceRef.current = () => {
     const waveEl = waveformRef.current?.querySelector("wave");
@@ -177,7 +172,6 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     return () => mediaQuery.removeEventListener("change", handler);
   }, []);
 
-  // Re-init when consumer toggles the explicit colorScheme prop.
   const prevColorSchemeRef = useRef(colorScheme);
   useEffect(() => {
     if (prevColorSchemeRef.current === colorScheme) return;

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -16,8 +16,7 @@ const waveformColors = {
 
 export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
-  const { isPlaying: isPlaybackActive, volume: playbackVolume } =
-    usePlaybackContext();
+  const { isPlaying: isPlaybackActive } = usePlaybackContext();
   const { curPlayId } = useTrackContext();
   const { elementRefs } = useResourceContext();
   const { colorScheme } = useUIContext();
@@ -102,9 +101,11 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
 
     waveform.load(audioEl);
 
-    if (playbackVolume != null) {
-      audioEl.volume = playbackVolume;
-    }
+    // Volume is owned by useAudio's volume effect. Writing it here during
+    // wavesurfer re-init (e.g. colorScheme change) would fire a DOM
+    // volumechange event while the previous wavesurfer instance's
+    // listener is still attached to audioEl — its `this.mediaElement` is
+    // already nulled by destroy(), so the listener throws.
 
     const onReady = () => {
       if (!isTrackChange && savedTime > 0 && audioEl.duration) {

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -81,6 +81,7 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [elementRefs?.waveformInst, audioPlayerDispatch, colorsRef]);
 
   /** load audio — preserve playback position across waveform init */
@@ -93,6 +94,10 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     prevPlayIdRef.current = curPlayId;
 
     const savedTime = isTrackChange ? 0 : audioEl.currentTime;
+    // Intentional stale capture: wasPlaying reads isPlaybackActive at the
+    // time waveform.load() is called so the onReady callback can resume
+    // playback without taking isPlaybackActive as a reactive dependency
+    // (which would re-run the effect on every play/pause toggle).
     const wasPlaying = isPlaybackActive;
 
     waveform.load(audioEl);
@@ -152,7 +157,7 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
   // Latest-closure ref so the media-query and colorScheme listeners below
   // always destroy the *current* waveformInst without taking it as a dep
   // (which would churn listener attachment on every waveform lifecycle).
-  const destroyInstanceRef = useRef<() => void>();
+  const destroyInstanceRef = useRef<(() => void) | undefined>(undefined);
   destroyInstanceRef.current = () => {
     const waveEl = waveformRef.current?.querySelector("wave");
     if (waveEl) {

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/useWavesurfer.ts
@@ -16,7 +16,7 @@ const waveformColors = {
 
 export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
-  const { curAudioState } = usePlaybackContext();
+  const { isPlaying, volume } = usePlaybackContext();
   const { curPlayId } = useTrackContext();
   const { elementRefs } = useResourceContext();
   const { colorScheme } = useUIContext();
@@ -92,12 +92,12 @@ export const useWaveSurfer = (waveformRef: React.RefObject<HTMLElement>) => {
     prevPlayIdRef.current = curPlayId;
 
     const savedTime = isTrackChange ? 0 : audioEl.currentTime;
-    const wasPlaying = curAudioState.isPlaying;
+    const wasPlaying = isPlaying;
 
     waveform.load(audioEl);
 
-    if (curAudioState.volume != null) {
-      audioEl.volume = curAudioState.volume;
+    if (volume != null) {
+      audioEl.volume = volume;
     }
 
     const onReady = () => {

--- a/package/src/components/AudioPlayer/Interface/Controller/Tooltip/Volume/Content.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Tooltip/Volume/Content.tsx
@@ -35,7 +35,6 @@ export const VolumeSlider: FC<{ placement: VolumeSliderPlacement }> = ({
   const resolvedVolume = volume ?? elementRefs?.audioEl?.volume ?? 0;
   const volumeValue = resolvedVolume * 100;
   const volumePercent = Math.round(volumeValue);
-  const isMuted = muted;
 
   const volumeStyle = useMemo(
     () =>
@@ -63,7 +62,7 @@ export const VolumeSlider: FC<{ placement: VolumeSliderPlacement }> = ({
           min="0"
           max="1"
           step="0.01"
-          aria-label={isMuted ? "Volume (muted)" : "Volume"}
+          aria-label={muted ? "Volume (muted)" : "Volume"}
           aria-valuetext={`${volumePercent} percent`}
         />
       </div>

--- a/package/src/components/AudioPlayer/Interface/Controller/Tooltip/Volume/Content.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Tooltip/Volume/Content.tsx
@@ -10,7 +10,7 @@ export const VolumeSlider: FC<{ placement: VolumeSliderPlacement }> = ({
   placement,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
-  const { curAudioState } = usePlaybackContext();
+  const { volume, muted } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
   const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
 
@@ -18,7 +18,7 @@ export const VolumeSlider: FC<{ placement: VolumeSliderPlacement }> = ({
     (e: ChangeEvent<HTMLInputElement>) => {
       e.stopPropagation();
       e.preventDefault();
-      if (curAudioState.muted) {
+      if (muted) {
         audioPlayerDispatch({ type: "SET_MUTED", muted: false });
       }
 
@@ -29,14 +29,13 @@ export const VolumeSlider: FC<{ placement: VolumeSliderPlacement }> = ({
         volume: parsedValue,
       });
     },
-    [curAudioState.muted, audioPlayerDispatch]
+    [muted, audioPlayerDispatch]
   );
 
-  const resolvedVolume =
-    curAudioState.volume ?? elementRefs?.audioEl?.volume ?? 0;
+  const resolvedVolume = volume ?? elementRefs?.audioEl?.volume ?? 0;
   const volumeValue = resolvedVolume * 100;
   const volumePercent = Math.round(volumeValue);
-  const isMuted = curAudioState.muted;
+  const isMuted = muted;
 
   const volumeStyle = useMemo(
     () =>

--- a/package/src/components/AudioPlayer/Interface/CustomComponent/index.tsx
+++ b/package/src/components/AudioPlayer/Interface/CustomComponent/index.tsx
@@ -25,9 +25,21 @@ export const CustomComponent: FC<CustomComponentProps> = ({
   const ui = useUIContext();
   const resource = useResourceContext();
 
-  // Assemble full state shape for backward-compat with custom component children
+  // Assemble full state shape for backward-compat with custom component
+  // children. The internal playbackContext was flattened in v2 — reconstruct
+  // the legacy `curAudioState` shape here so external consumers continue to
+  // see the nested object they were originally written against.
   const audioPlayerState = {
-    ...playback,
+    curAudioState: {
+      isPlaying: playback.isPlaying,
+      volume: playback.volume,
+      muted: playback.muted,
+      repeatType: playback.repeatType,
+      isLoadedMetaData: playback.isLoadedMetaData,
+      currentTime: time.currentTime,
+      duration: time.duration,
+    },
+    audioResetKey: playback.audioResetKey,
     ...time,
     ...track,
     ...ui,

--- a/package/src/components/Provider/AudioPlayerProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerProvider.tsx
@@ -7,6 +7,10 @@ import {
   Placements,
 } from "@/components/AudioPlayer/Context";
 import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContext";
+import {
+  AudioAttrsContext,
+  audioAttrsContext,
+} from "@/components/AudioPlayer/Context/AudioAttrsContext";
 import { timeContext } from "@/components/AudioPlayer/Context/TimeContext";
 import { trackContext } from "@/components/AudioPlayer/Context/TrackContext";
 import { uiContext } from "@/components/AudioPlayer/Context/UIContext";
@@ -125,6 +129,35 @@ export const AudioPlayerProvider = <
     ]
   );
 
+  // Native HTML <audio> attributes piped through audioInitialState
+  // (controls, preload, loop, crossOrigin, playsInline, ...). Derived from
+  // the prop reference rather than reducer state so per-tick playback
+  // dispatches do not invalidate this object and force <Audio> to re-render.
+  const audioAttrsValue = useMemo<AudioAttrsContext>(() => {
+    if (!audioInitialState) return {};
+    const {
+      isPlaying: _isPlaying,
+      repeatType: _repeatType,
+      isLoadedMetaData: _isLoadedMetaData,
+      currentTime: _currentTime,
+      duration: _duration,
+      volume: _volume,
+      muted: _muted,
+      curPlayId: _curPlayId,
+      ...nativeAttrs
+    } = audioInitialState as AudioAttrsContext & {
+      isPlaying?: unknown;
+      repeatType?: unknown;
+      isLoadedMetaData?: unknown;
+      currentTime?: unknown;
+      duration?: unknown;
+      volume?: unknown;
+      muted?: unknown;
+      curPlayId?: unknown;
+    };
+    return nativeAttrs;
+  }, [audioInitialState]);
+
   const resourceValue = useMemo(
     () => ({
       elementRefs: state.elementRefs,
@@ -145,9 +178,11 @@ export const AudioPlayerProvider = <
         <trackContext.Provider value={trackValue}>
           <uiContext.Provider value={uiValue}>
             <resourceContext.Provider value={resourceValue}>
-              <audioPlayerDispatchContext.Provider value={dispatch}>
-                {children}
-              </audioPlayerDispatchContext.Provider>
+              <audioAttrsContext.Provider value={audioAttrsValue}>
+                <audioPlayerDispatchContext.Provider value={dispatch}>
+                  {children}
+                </audioPlayerDispatchContext.Provider>
+              </audioAttrsContext.Provider>
             </resourceContext.Provider>
           </uiContext.Provider>
         </trackContext.Provider>

--- a/package/src/components/Provider/AudioPlayerProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerProvider.tsx
@@ -129,11 +129,9 @@ export const AudioPlayerProvider = <
     ]
   );
 
-  // Native HTML <audio> attributes piped through audioInitialState
-  // (controls, preload, loop, crossOrigin, playsInline, ...). Derived from
-  // the prop reference rather than reducer state so per-tick playback
-  // dispatches do not invalidate this object and force <Audio> to re-render.
-  const audioAttrsValue = useMemo<AudioAttrsContext>(() => {
+  // Sourced from the audioInitialState prop reference (not reducer state)
+  // so per-tick SET_AUDIO_STATE dispatches never invalidate this object.
+  const audioNativeAttrsValue = useMemo<AudioAttrsContext>(() => {
     if (!audioInitialState) return {};
     const {
       isPlaying: _isPlaying,
@@ -145,16 +143,8 @@ export const AudioPlayerProvider = <
       muted: _muted,
       curPlayId: _curPlayId,
       ...nativeAttrs
-    } = audioInitialState as AudioAttrsContext & {
-      isPlaying?: unknown;
-      repeatType?: unknown;
-      isLoadedMetaData?: unknown;
-      currentTime?: unknown;
-      duration?: unknown;
-      volume?: unknown;
-      muted?: unknown;
-      curPlayId?: unknown;
-    };
+    } = audioInitialState;
+
     return nativeAttrs;
   }, [audioInitialState]);
 
@@ -178,7 +168,7 @@ export const AudioPlayerProvider = <
         <trackContext.Provider value={trackValue}>
           <uiContext.Provider value={uiValue}>
             <resourceContext.Provider value={resourceValue}>
-              <audioAttrsContext.Provider value={audioAttrsValue}>
+              <audioAttrsContext.Provider value={audioNativeAttrsValue}>
                 <audioPlayerDispatchContext.Provider value={dispatch}>
                   {children}
                 </audioPlayerDispatchContext.Provider>

--- a/package/src/components/Provider/AudioPlayerProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerProvider.tsx
@@ -70,6 +70,7 @@ export const AudioPlayerProvider = <
     curAudioState,
     activeUI,
     audioResetKey: 0,
+    seekRequestKey: 0,
     ...(placement as Placements<10>),
     ...otherProps,
   });
@@ -78,8 +79,13 @@ export const AudioPlayerProvider = <
     () => ({
       currentTime: state.curAudioState.currentTime ?? 0,
       duration: state.curAudioState.duration ?? 0,
+      seekRequestKey: state.seekRequestKey,
     }),
-    [state.curAudioState.currentTime, state.curAudioState.duration]
+    [
+      state.curAudioState.currentTime,
+      state.curAudioState.duration,
+      state.seekRequestKey,
+    ]
   );
 
   const playbackValue = useMemo(

--- a/package/src/components/Provider/AudioPlayerProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerProvider.tsx
@@ -84,9 +84,9 @@ export const AudioPlayerProvider = <
 
   const playbackValue = useMemo(
     () => ({
-      isPlaying: state.curAudioState.isPlaying,
-      volume: state.curAudioState.volume,
-      muted: state.curAudioState.muted,
+      isPlaying: state.curAudioState.isPlaying ?? false,
+      volume: state.curAudioState.volume ?? 1,
+      muted: state.curAudioState.muted ?? false,
       repeatType: state.curAudioState.repeatType,
       isLoadedMetaData: state.curAudioState.isLoadedMetaData,
       audioResetKey: state.audioResetKey,

--- a/package/src/components/Provider/AudioPlayerProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerProvider.tsx
@@ -80,7 +80,11 @@ export const AudioPlayerProvider = <
 
   const playbackValue = useMemo(
     () => ({
-      curAudioState: state.curAudioState,
+      isPlaying: state.curAudioState.isPlaying,
+      volume: state.curAudioState.volume,
+      muted: state.curAudioState.muted,
+      repeatType: state.curAudioState.repeatType,
+      isLoadedMetaData: state.curAudioState.isLoadedMetaData,
       audioResetKey: state.audioResetKey,
     }),
     [

--- a/package/src/components/Provider/AudioPlayerRootProvider.tsx
+++ b/package/src/components/Provider/AudioPlayerRootProvider.tsx
@@ -63,10 +63,10 @@ export const AudioPlayerRootProvider: FC<
   return (
     <div
       {...rootContainerProps}
-      className={`rm-audio-player-provider${
+      className={`rmap-player-provider${
         rootContainerProps?.className ? ` ${rootContainerProps.className}` : ""
       }`}
-      data-theme={colorScheme}
+      data-theme={colorScheme ?? undefined}
       style={style}
     >
       {children}

--- a/package/src/components/Provider/__tests__/AudioPlayerRootProvider.test.tsx
+++ b/package/src/components/Provider/__tests__/AudioPlayerRootProvider.test.tsx
@@ -41,10 +41,10 @@ describe("base class", () => {
     mockPlacement(undefined);
   });
 
-  it("rm-audio-player-provider class always present", () => {
+  it("rmap-player-provider class always present", () => {
     const { container } = renderProvider();
     const el = container.firstChild as HTMLElement;
-    expect(el.classList.contains("rm-audio-player-provider")).toBe(true);
+    expect(el.classList.contains("rmap-player-provider")).toBe(true);
   });
 
   it("rootContainerProps.className appended", () => {
@@ -52,13 +52,13 @@ describe("base class", () => {
       rootContainerProps: { className: "custom-class" },
     });
     const el = container.firstChild as HTMLElement;
-    expect(el.className).toBe("rm-audio-player-provider custom-class");
+    expect(el.className).toBe("rmap-player-provider custom-class");
   });
 
   it("no trailing space when className absent", () => {
     const { container } = renderProvider();
     const el = container.firstChild as HTMLElement;
-    expect(el.className).toBe("rm-audio-player-provider");
+    expect(el.className).toBe("rmap-player-provider");
   });
 });
 

--- a/package/src/components/Provider/__tests__/context-isolation.test.tsx
+++ b/package/src/components/Provider/__tests__/context-isolation.test.tsx
@@ -24,24 +24,16 @@ import { useTrackContext } from "@/hooks/context/useTrackContext";
 import { useUIContext } from "@/hooks/context/useUIContext";
 import { useResourceContext } from "@/hooks/context/useResourceContext";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures
-// ─────────────────────────────────────────────────────────────────────────────
-
 const basePlayList = [
   { id: 1, src: "a.mp3" },
   { id: 2, src: "b.mp3" },
   { id: 3, src: "c.mp3" },
 ];
 
-// ─────────────────────────────────────────────────────────────────────────────
-// DispatchCapture
 // Reads the dispatch context in render and stores it in a ref so tests can
 // call dispatch outside of React without needing a button or user-event.
 // Writing to a ref in the render body (not useEffect) is intentional —
 // it populates the ref synchronously before render() returns.
-// ─────────────────────────────────────────────────────────────────────────────
-
 type DispatchRef = { current: ((action: AudioContextAction) => void) | null };
 
 const DispatchCapture: FC<{ dispatchRef: DispatchRef }> = ({ dispatchRef }) => {
@@ -49,12 +41,8 @@ const DispatchCapture: FC<{ dispatchRef: DispatchRef }> = ({ dispatchRef }) => {
   return null;
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
-// renderIsolated
 // Renders AudioPlayerProvider without StrictMode so render-body counters are
 // not inflated by React's double-invoke behaviour in development.
-// ─────────────────────────────────────────────────────────────────────────────
-
 function renderIsolated(children: ReactNode, curPlayId = 1) {
   const dispatchRef: DispatchRef = { current: null };
   render(
@@ -69,13 +57,9 @@ function renderIsolated(children: ReactNode, curPlayId = 1) {
   return dispatchRef as { current: (action: AudioContextAction) => void };
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// makeProbes
 // Creates fresh probe component types and independent render counters per test.
 // Components are defined inside this factory so each test gets unique function
 // references — React will not try to reconcile across test renders.
-// ─────────────────────────────────────────────────────────────────────────────
-
 function makeProbes() {
   let playbackCount = 0;
   let timeCount = 0;
@@ -128,10 +112,6 @@ function makeProbes() {
   };
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
 /** All four probes as a JSX fragment — mount them all for full isolation coverage. */
 function AllProbes({
   PlaybackProbe,
@@ -150,10 +130,6 @@ function AllProbes({
     </>
   );
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Tests
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("playbackContext isolation", () => {
   it("CHANGE_PLAYING_STATE only re-renders playback consumers", () => {

--- a/package/src/components/Provider/__tests__/context-isolation.test.tsx
+++ b/package/src/components/Provider/__tests__/context-isolation.test.tsx
@@ -446,7 +446,7 @@ describe("cross-context actions — intentional multi-slice updates", () => {
     const dispatch = renderIsolated(<AllProbes {...probes} />, 2);
     const base = probes.snapshot();
 
-    act(() => dispatch.current({ type: "PREV_AUDIO" }));
+    act(() => dispatch.current({ type: "PREV_AUDIO", currentTime: 0 }));
 
     const after = probes.snapshot();
     expect(after.trackCount - base.trackCount).toBe(1);

--- a/package/src/hooks/__tests__/useAudioPlayer.test.tsx
+++ b/package/src/hooks/__tests__/useAudioPlayer.test.tsx
@@ -9,8 +9,6 @@ import { renderHook, act } from "@testing-library/react";
 import { FC, ReactNode } from "react";
 import { AudioPlayerProvider } from "@/components/Provider/AudioPlayerProvider";
 import { useAudioPlayer } from "../useAudioPlayer";
-import { useNonNullableContext } from "../useNonNullableContext";
-import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -202,33 +200,18 @@ describe("setVolume", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("seek", () => {
-  it("sets audioEl.currentTime when audioEl is present", () => {
-    const audioEl = document.createElement("audio");
-    Object.defineProperty(audioEl, "currentTime", {
-      writable: true,
-      value: 0,
-    });
-
-    const { result } = renderHook(
-      () => ({
-        player: useAudioPlayer(),
-        dispatch: useNonNullableContext(audioPlayerDispatchContext),
-      }),
-      { wrapper: Wrapper }
-    );
-
-    act(() => {
-      result.current.dispatch({
-        type: "SET_ELEMENT_REFS",
-        elementRefs: { audioEl },
-      });
+  it("dispatches the new currentTime so timeContext consumers see it", () => {
+    // seek() is now a pure dispatch — DOM sync is handled by useAudio's
+    // effect once the resulting state change reaches the <Audio> element.
+    const { result } = renderHook(() => useAudioPlayer(), {
+      wrapper: Wrapper,
     });
 
     act(() => {
-      result.current.player.seek(30);
+      result.current.seek(30);
     });
 
-    expect(audioEl.currentTime).toBe(30);
+    expect(result.current.currentTime).toBe(30);
   });
 
   it("does not throw when audioEl is absent", () => {

--- a/package/src/hooks/__tests__/useAudioPlayer.test.tsx
+++ b/package/src/hooks/__tests__/useAudioPlayer.test.tsx
@@ -10,10 +10,6 @@ import { FC, ReactNode } from "react";
 import { AudioPlayerProvider } from "@/components/Provider/AudioPlayerProvider";
 import { useAudioPlayer } from "../useAudioPlayer";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures
-// ─────────────────────────────────────────────────────────────────────────────
-
 const basePlayList = [
   { id: 1, src: "a.mp3" },
   { id: 2, src: "b.mp3" },
@@ -29,10 +25,6 @@ beforeEach(() => {
   window.HTMLMediaElement.prototype.pause = vi.fn();
   window.HTMLMediaElement.prototype.load = vi.fn();
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Initial state
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("initial state", () => {
   it("returns correct defaults", () => {
@@ -51,10 +43,6 @@ describe("initial state", () => {
     expect(result.current.playList).toEqual(basePlayList);
   });
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Playback actions
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("play / pause / togglePlay", () => {
   it("play() sets isPlaying to true", () => {
@@ -90,10 +78,6 @@ describe("play / pause / togglePlay", () => {
     expect(result.current.isPlaying).toBe(false);
   });
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Track navigation
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("next / prev", () => {
   it("next() advances to the next track", () => {
@@ -132,10 +116,6 @@ describe("next / prev", () => {
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// setTrack
-// ─────────────────────────────────────────────────────────────────────────────
-
 describe("setTrack", () => {
   it("jumps to the specified index", () => {
     const { result } = renderHook(() => useAudioPlayer(), {
@@ -158,10 +138,6 @@ describe("setTrack", () => {
     expect(result.current.currentIndex).toBe(0);
   });
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Volume
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("setVolume", () => {
   it("updates volume", () => {
@@ -195,10 +171,6 @@ describe("setVolume", () => {
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// seek
-// ─────────────────────────────────────────────────────────────────────────────
-
 describe("seek", () => {
   it("dispatches the new currentTime so timeContext consumers see it", () => {
     // seek() is now a pure dispatch — DOM sync is handled by useAudio's
@@ -222,10 +194,6 @@ describe("seek", () => {
     expect(() => act(() => result.current.seek(30))).not.toThrow();
   });
 });
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Error boundary — outside provider
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("error handling", () => {
   it("throws when used outside AudioPlayerProvider", () => {

--- a/package/src/hooks/context/index.ts
+++ b/package/src/hooks/context/index.ts
@@ -3,3 +3,4 @@ export * from "./useTimeContext";
 export * from "./useTrackContext";
 export * from "./useUIContext";
 export * from "./useResourceContext";
+export * from "./useAudioAttrsContext";

--- a/package/src/hooks/context/useAudioAttrsContext.ts
+++ b/package/src/hooks/context/useAudioAttrsContext.ts
@@ -1,0 +1,8 @@
+import {
+  AudioAttrsContext,
+  audioAttrsContext,
+} from "@/components/AudioPlayer/Context/AudioAttrsContext";
+import { useNonNullableContext } from "../useNonNullableContext";
+
+export const useAudioAttrsContext = (): AudioAttrsContext =>
+  useNonNullableContext(audioAttrsContext);

--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -56,17 +56,13 @@ export const useAudioPlayer = (): AudioPlayerControls => {
 
   const prev = useCallback(() => {
     if (playList.length === 0) return;
-    const currentTime =
-      elementRefs?.waveformInst?.getCurrentTime() ??
-      elementRefs?.audioEl?.currentTime ??
-      0;
+    // wavesurfer wraps the same `<audio>` element via the MediaElement
+    // backend (useWavesurfer.ts), so reading audioEl.currentTime covers
+    // both bar and waveform progress modes. The legacy reducer used to
+    // OR audioEl and waveformInst reads but that branch was dead.
+    const currentTime = elementRefs?.audioEl?.currentTime ?? 0;
     dispatch({ type: "PREV_AUDIO", currentTime });
-  }, [
-    dispatch,
-    playList.length,
-    elementRefs?.audioEl,
-    elementRefs?.waveformInst,
-  ]);
+  }, [dispatch, playList.length, elementRefs?.audioEl]);
 
   const seek = useCallback(
     (time: number) => {

--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -66,10 +66,7 @@ export const useAudioPlayer = (): AudioPlayerControls => {
 
   const seek = useCallback(
     (time: number) => {
-      dispatch({
-        type: "SET_AUDIO_STATE",
-        audioState: { currentTime: time },
-      });
+      dispatch({ type: "SEEK", time });
     },
     [dispatch]
   );

--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -32,7 +32,7 @@ export interface AudioPlayerControls {
 
 export const useAudioPlayer = (): AudioPlayerControls => {
   const dispatch = useNonNullableContext(audioPlayerDispatchContext);
-  const { curAudioState } = usePlaybackContext();
+  const playback = usePlaybackContext();
   const { currentTime, duration } = useTimeContext();
   const { playList, curIdx } = useTrackContext();
   const { elementRefs } = useResourceContext();
@@ -56,20 +56,26 @@ export const useAudioPlayer = (): AudioPlayerControls => {
 
   const prev = useCallback(() => {
     if (playList.length === 0) return;
-    dispatch({ type: "PREV_AUDIO" });
-  }, [dispatch, playList.length]);
+    const currentTime =
+      elementRefs?.waveformInst?.getCurrentTime() ??
+      elementRefs?.audioEl?.currentTime ??
+      0;
+    dispatch({ type: "PREV_AUDIO", currentTime });
+  }, [
+    dispatch,
+    playList.length,
+    elementRefs?.audioEl,
+    elementRefs?.waveformInst,
+  ]);
 
   const seek = useCallback(
     (time: number) => {
-      if (elementRefs?.audioEl) {
-        elementRefs.audioEl.currentTime = time;
-        dispatch({
-          type: "SET_AUDIO_STATE",
-          audioState: { currentTime: time },
-        });
-      }
+      dispatch({
+        type: "SET_AUDIO_STATE",
+        audioState: { currentTime: time },
+      });
     },
-    [elementRefs?.audioEl, dispatch]
+    [dispatch]
   );
 
   const setVolume = useCallback(
@@ -93,12 +99,12 @@ export const useAudioPlayer = (): AudioPlayerControls => {
   );
 
   return {
-    isPlaying: curAudioState.isPlaying ?? false,
-    volume: curAudioState.volume ?? 1,
+    isPlaying: playback.isPlaying ?? false,
+    volume: playback.volume ?? 1,
     currentTime,
     duration,
-    repeatType: curAudioState.repeatType ?? "ALL",
-    muted: curAudioState.muted ?? false,
+    repeatType: playback.repeatType ?? "ALL",
+    muted: playback.muted ?? false,
     currentTrack: playList[curIdx] ?? null,
     currentIndex: curIdx,
     playList,

--- a/package/src/hooks/useAudioPlayer.ts
+++ b/package/src/hooks/useAudioPlayer.ts
@@ -60,8 +60,8 @@ export const useAudioPlayer = (): AudioPlayerControls => {
     // backend (useWavesurfer.ts), so reading audioEl.currentTime covers
     // both bar and waveform progress modes. The legacy reducer used to
     // OR audioEl and waveformInst reads but that branch was dead.
-    const currentTime = elementRefs?.audioEl?.currentTime ?? 0;
-    dispatch({ type: "PREV_AUDIO", currentTime });
+    const audioElCurrentTime = elementRefs?.audioEl?.currentTime ?? 0;
+    dispatch({ type: "PREV_AUDIO", currentTime: audioElCurrentTime });
   }, [dispatch, playList.length, elementRefs?.audioEl]);
 
   const seek = useCallback(

--- a/package/src/hooks/useVariableColor.ts
+++ b/package/src/hooks/useVariableColor.ts
@@ -13,7 +13,7 @@ export const useVariableColor = <Keys extends string>(
   const colorsRef = useRef<VariableColors<Keys>>();
 
   const readColors = useCallback(() => {
-    const el = document.getElementsByClassName("rm-audio-player-provider")[0];
+    const el = document.getElementsByClassName("rmap-player-provider")[0];
     if (!el) return;
     const parsedColors: VariableColors<Keys> = Object.entries(
       variableColors

--- a/package/src/styles/GlobalStyle.css
+++ b/package/src/styles/GlobalStyle.css
@@ -1,34 +1,34 @@
-.rm-audio-player-provider * {
+.rmap-player-provider * {
   box-sizing: border-box;
   font: inherit;
   font-size: 100%;
 }
 
-.rm-audio-player-provider ol,
-.rm-audio-player-provider ul {
+.rmap-player-provider ol,
+.rmap-player-provider ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.rm-audio-player-provider blockquote,
-.rm-audio-player-provider q {
+.rmap-player-provider blockquote,
+.rmap-player-provider q {
   quotes: none;
 }
 
-.rm-audio-player-provider blockquote:before,
-.rm-audio-player-provider blockquote:after,
-.rm-audio-player-provider q:before,
-.rm-audio-player-provider q:after {
+.rmap-player-provider blockquote:before,
+.rmap-player-provider blockquote:after,
+.rmap-player-provider q:before,
+.rmap-player-provider q:after {
   content: none;
 }
 
-.rm-audio-player-provider table {
+.rmap-player-provider table {
   border-collapse: collapse;
   border-spacing: 0;
 }
 
-.rm-audio-player-provider button {
+.rmap-player-provider button {
   margin: 0;
   padding: 0;
   background: transparent;

--- a/package/src/styles/vars.css
+++ b/package/src/styles/vars.css
@@ -1,4 +1,4 @@
-.rm-audio-player-provider {
+.rmap-player-provider {
   --rm-audio-player-text-color: #2c2c2c;
   --rm-audio-player-shadow: 0 0 0;
   --rm-audio-player-interface-container: #f5f5f5;
@@ -25,7 +25,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .rm-audio-player-provider:not([data-theme="light"]) {
+  .rmap-player-provider:not([data-theme="light"]) {
     --rm-audio-player-text-color: #ededed;
     --rm-audio-player-shadow: 255 255 255;
     --rm-audio-player-interface-container: #1e1e1e;
@@ -50,7 +50,8 @@
   }
 }
 
-.rm-audio-player-provider[data-theme="dark"] {
+/* Keep in sync with @media (prefers-color-scheme: dark) block above */
+.rmap-player-provider[data-theme="dark"] {
   --rm-audio-player-text-color: #ededed;
   --rm-audio-player-shadow: 255 255 255;
   --rm-audio-player-interface-container: #1e1e1e;

--- a/package/src/ui/CssTransition.tsx
+++ b/package/src/ui/CssTransition.tsx
@@ -34,8 +34,7 @@ export const CssTransition: FC<PropsWithChildren<CssTransitionProps>> = ({
 
     setClassNames(`${name}-${statusClassName}`);
 
-    // set class to active
-    const timer = setTimeout(() => {
+    const activateClassTimer = setTimeout(() => {
       setClassNames(
         `${name}-${statusClassName} ${name}-${statusClassName}-active`
       );
@@ -44,21 +43,20 @@ export const CssTransition: FC<PropsWithChildren<CssTransitionProps>> = ({
       } else {
         onEntered?.();
       }
-      clearTimeout(timer);
+      clearTimeout(activateClassTimer);
     }, time);
 
-    // remove classNames when animation over
-    const clearClassesTimer = setTimeout(() => {
+    const resetClassesTimer = setTimeout(() => {
       if (!visible) {
         setClassNames(name);
         setRenderable(false);
       }
-      clearTimeout(clearClassesTimer);
+      clearTimeout(resetClassesTimer);
     }, time + clearTime);
 
     return () => {
-      clearTimeout(timer);
-      clearTimeout(clearClassesTimer);
+      clearTimeout(activateClassTimer);
+      clearTimeout(resetClassesTimer);
     };
   }, [visible, renderable]);
 

--- a/package/src/ui/CssTransition.tsx
+++ b/package/src/ui/CssTransition.tsx
@@ -1,4 +1,10 @@
-import React, { cloneElement, FC, PropsWithChildren, useState } from "react";
+import React, {
+  cloneElement,
+  FC,
+  PropsWithChildren,
+  useRef,
+  useState,
+} from "react";
 import { useIsomorphicLayoutEffect } from "@/utils/ssr";
 import "@/styles/animations.css";
 
@@ -25,34 +31,50 @@ export const CssTransition: FC<PropsWithChildren<CssTransitionProps>> = ({
   const [classNames, setClassNames] = useState("");
   const [renderable, setRenderable] = useState(false);
 
+  // Latest-ref mirrors so the timer callbacks below always invoke the
+  // newest props without taking them as effect dependencies. Adding the
+  // raw props to the dep array would restart the timers on every parent
+  // render that recreates the callback identity, breaking the animation.
+  const onEnteredRef = useRef(onEntered);
+  const onExitedRef = useRef(onExited);
+  const nameRef = useRef(name);
+  const enterTimeRef = useRef(enterTime);
+  const leaveTimeRef = useRef(leaveTime);
+  const clearTimeRef = useRef(clearTime);
+  onEnteredRef.current = onEntered;
+  onExitedRef.current = onExited;
+  nameRef.current = name;
+  enterTimeRef.current = enterTime;
+  leaveTimeRef.current = leaveTime;
+  clearTimeRef.current = clearTime;
+
   useIsomorphicLayoutEffect(() => {
     const statusClassName = visible ? "enter" : "leave";
-    const time = visible ? enterTime : leaveTime;
+    const transitionName = nameRef.current;
+    const time = visible ? enterTimeRef.current : leaveTimeRef.current;
     if (visible && !renderable) {
       setRenderable(true);
     }
 
-    setClassNames(`${name}-${statusClassName}`);
+    setClassNames(`${transitionName}-${statusClassName}`);
 
     const activateClassTimer = setTimeout(() => {
       setClassNames(
-        `${name}-${statusClassName} ${name}-${statusClassName}-active`
+        `${transitionName}-${statusClassName} ${transitionName}-${statusClassName}-active`
       );
       if (statusClassName === "leave") {
-        onExited?.();
+        onExitedRef.current?.();
       } else {
-        onEntered?.();
+        onEnteredRef.current?.();
       }
-      clearTimeout(activateClassTimer);
     }, time);
 
     const resetClassesTimer = setTimeout(() => {
       if (!visible) {
-        setClassNames(name);
+        setClassNames(transitionName);
         setRenderable(false);
       }
-      clearTimeout(resetClassesTimer);
-    }, time + clearTime);
+    }, time + clearTimeRef.current);
 
     return () => {
       clearTimeout(activateClassTimer);

--- a/package/src/ui/CssTransition.tsx
+++ b/package/src/ui/CssTransition.tsx
@@ -41,12 +41,20 @@ export const CssTransition: FC<PropsWithChildren<CssTransitionProps>> = ({
   const enterTimeRef = useRef(enterTime);
   const leaveTimeRef = useRef(leaveTime);
   const clearTimeRef = useRef(clearTime);
-  onEnteredRef.current = onEntered;
-  onExitedRef.current = onExited;
-  nameRef.current = name;
-  enterTimeRef.current = enterTime;
-  leaveTimeRef.current = leaveTime;
-  clearTimeRef.current = clearTime;
+
+  // Sync the mirrors inside a committed layout effect — never in the
+  // render body. Under Concurrent Mode an interrupted render could
+  // otherwise leak uncommitted values into timeouts scheduled by a
+  // prior commit's effect. Declared before the animation effect so
+  // the same commit cycle always refreshes the refs first.
+  useIsomorphicLayoutEffect(() => {
+    onEnteredRef.current = onEntered;
+    onExitedRef.current = onExited;
+    nameRef.current = name;
+    enterTimeRef.current = enterTime;
+    leaveTimeRef.current = leaveTime;
+    clearTimeRef.current = clearTime;
+  });
 
   useIsomorphicLayoutEffect(() => {
     const statusClassName = visible ? "enter" : "leave";

--- a/package/src/ui/__tests__/CssTransition.test.tsx
+++ b/package/src/ui/__tests__/CssTransition.test.tsx
@@ -1,0 +1,143 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CssTransition } from "../CssTransition";
+
+// Latest-ref regression: timer callbacks must invoke the most recent
+// onEntered / onExited prop, not the closure captured at the first
+// render. Without the latest-ref mirrors the effect would either skip
+// re-binding (stale callback fires) or restart the timers on every
+// parent re-render that recreates the callback identity.
+
+describe("CssTransition latest-ref callback handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes the LATEST onEntered when the prop changes between mount and timer fire", () => {
+    const firstCallback = vi.fn();
+    const replacedCallback = vi.fn();
+
+    const { rerender } = render(
+      <CssTransition
+        visible={true}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onEntered={firstCallback}
+      >
+        <div className="rmap-test-child" />
+      </CssTransition>
+    );
+
+    rerender(
+      <CssTransition
+        visible={true}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onEntered={replacedCallback}
+      >
+        <div className="rmap-test-child" />
+      </CssTransition>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(25);
+    });
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(replacedCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes the LATEST onExited after toggling visible=false with a fresh callback", () => {
+    const firstExitCallback = vi.fn();
+    const replacedExitCallback = vi.fn();
+
+    const { rerender } = render(
+      <CssTransition
+        visible={true}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onExited={firstExitCallback}
+      >
+        <div />
+      </CssTransition>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(25);
+    });
+    expect(firstExitCallback).not.toHaveBeenCalled();
+
+    rerender(
+      <CssTransition
+        visible={false}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onExited={replacedExitCallback}
+      >
+        <div />
+      </CssTransition>
+    );
+
+    vi.advanceTimersByTime(25);
+
+    expect(firstExitCallback).not.toHaveBeenCalled();
+    expect(replacedExitCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT restart the enter timer when only the callback identity changes", () => {
+    // Parent re-renders that recreate inline arrow callbacks should not
+    // cancel + restart the in-flight transition timer. If the timer were
+    // tied to callback identity, advancing past enterTime once would not
+    // be enough — the rerender would have reset the clock.
+    const callback = vi.fn();
+
+    const { rerender } = render(
+      <CssTransition
+        visible={true}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onEntered={() => callback("first identity")}
+      >
+        <div />
+      </CssTransition>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    rerender(
+      <CssTransition
+        visible={true}
+        name="rmap-test"
+        enterTime={20}
+        leaveTime={20}
+        clearTime={300}
+        onEntered={() => callback("second identity")}
+      >
+        <div />
+      </CssTransition>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(15);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("second identity");
+  });
+});

--- a/test/e2e/ui-placement.spec.ts
+++ b/test/e2e/ui-placement.spec.ts
@@ -3,7 +3,7 @@ import type { Locator } from "@playwright/test";
 
 test.describe("PlayerPlacement — position", () => {
   test("static (default) → position is not fixed", async ({ playerPage }) => {
-    const provider = playerPage.page.locator(".rm-audio-player-provider");
+    const provider = playerPage.page.locator(".rmap-player-provider");
     const position = await provider.evaluate(
       (el) => getComputedStyle(el).position
     );
@@ -27,7 +27,7 @@ test.describe("PlayerPlacement — position", () => {
       playerPageLazy,
     }) => {
       await playerPageLazy.gotoWithConfig({ playerPlacement: placement });
-      const provider = playerPageLazy.page.locator(".rm-audio-player-provider");
+      const provider = playerPageLazy.page.locator(".rmap-player-provider");
 
       const position = await provider.evaluate(
         (el) => getComputedStyle(el).position


### PR DESCRIPTION
## Summary

Phase 2 of `.claude/docs/v2-final-overhaul.md` plus follow-up stabilization. Targets reducer purity, playback context flattening, the seek dispatch contract, native audio attribute passthrough, and a repeat-ONE / track-transition race in the seek sync effect.

## Commits

| SHA | Subject |
|---|---|
| `2c6e843` | ♻️ refactor(v2): purify reducer and flatten playback context |
| `2f48eb0` | 🐛 fix(audio): prevent repeat ONE jump-to-end and seekTo NaN race |
| `642f296` | 🐛 fix(provider): restore native audio attr passthrough |
| `722ab7f` | ♻️ refactor(playback): tighten conventions and drop dead branches |
| `4c172ff` | 📝 docs(conventions): add comments-as-last-resort rule |

## Key changes

### 2.1 PREV_AUDIO purification
- Action carries `currentTime: number` payload; reducer no longer reaches into `elementRefs.audioEl` / `waveformInst`.
- Threshold extracted to `PREV_RESET_THRESHOLD_SEC`; branch decisions named (`isSingleTrackPlaylist`, `shouldRewindToStart`, `isFirstTrackNoRepeat`).
- Call sites (`PrevNnextBtn`, `useAudioPlayer.prev`) read currentTime from refs before dispatching.

### 2.2 playbackContext flattened
- Shape: `{ isPlaying, volume, muted, repeatType, isLoadedMetaData, audioResetKey }`.
- Removes the stale `curAudioState` reference held inside `useMemo`; deps now align with what consumers actually read.
- All internal consumers updated to read flat primitives. `CustomComponent` rebuilds the legacy nested shape so the public `audioPlayerState` surface is unchanged for external consumers.

### 2.3 seek dispatch only
- `useAudioPlayer.seek` dispatches `SET_AUDIO_STATE { currentTime }` with no DOM write.
- New seek sync effect in `useAudio` mirrors state into `audioEl.currentTime` and `waveform.seekTo`, guarded by a 0.25s threshold so `onTimeUpdate` feedback does not loop.
- Ratio guard (`Number.isFinite(duration) && duration > 0`) and `[0, 1]` clamp keep the effect safe across track-change races.

### 2.4 reducer test purity
- PREV_AUDIO rewind branch verified with payload only — no mock `<audio>` element.
- Context-isolation test updated for the new PREV_AUDIO payload signature.
- `useAudioPlayer.seek` test asserts the dispatched `currentTime` instead of a DOM mutation.

## Bug fixes shipped alongside

### Native HTML `<audio>` attribute passthrough (`642f296`)
Phase 2.2 dropped the implicit `curAudioState` spread inside `<Audio>`, which silently regressed `controls` / `preload` / `loop` / `crossOrigin` / `playsInline` attributes that consumers pipe in via `audioInitialState`. The passthrough was undocumented in `.claude/docs/repo-analysis`, so the regression slipped through.

Fix introduces a dedicated `audioAttrsContext` sourced directly from the `audioInitialState` prop reference (not reducer state), so the value object is stable across per-tick `SET_AUDIO_STATE` dispatches. `<Audio>` is the sole consumer. Documents the contract in `05-flow.md`.

### Repeat ONE jump-to-end + seekTo NaN race (`2f48eb0`)
Two visible bugs in the seek sync effect:

- **Repeat ONE end → restart**: `onEnded` wrote `audioEl.currentTime = 0` directly without dispatching state. A pending `onTimeUpdate` at ~end rendered after the reset and the seek sync effect treated the stale near-end state as the desired position, jumping the freshly-restarted track straight back to its end.
- **NEXT_AUDIO transition**: `waveform.seekTo` could receive `NaN` / `Infinity` / out-of-range ratios while `audioEl.duration` was transiently `NaN` (metadata loading) or out-of-sync with `playbackCurrentTime`, throwing `parameter must be a number between 0 and 1`.

Fix routes the repeat-ONE reset through dispatch under `flushSync`, so the seek sync effect commits `audioEl.currentTime = 0` before `play()` runs. Single source of truth for the DOM write.

## Tests

- 217 tests pass (was 207 before this PR).
- New `src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx` — 10 cases:
  - 8 seek-sync edges (threshold skip, missing waveform, NaN/0/Infinity duration, ratio > 1 / < 0 clamp, normal ratio dispatch).
  - 2 onEnded contracts (repeat ONE flushSync dispatch + play, non-ONE NEXT_AUDIO dispatch).

## Convention update

`conventions/code-naming.md` adds a "Comments" section formalizing comments as a last resort. Drove the follow-up comment prune across `useAudio`, `CssTransition`, `useWavesurfer`, `RepeatTypeBtn`, `AudioPlayerProvider`, and the three test files.

## Test plan

- [ ] Run unit + integration tests locally (`yarn test`)
- [ ] Manual: PREV button at 0.5s / 2s / first track in NONE/ALL/SHUFFLE
- [ ] Manual: seek via bar progress, keyboard, and `useAudioPlayer.seek` API in both bar and waveform modes
- [ ] Manual: repeat ONE — track plays to end and restarts cleanly from 0 (no jump-to-end glitch)
- [ ] Manual: NEXT_AUDIO auto-transition — no `seekTo` console errors
- [ ] Manual: pass `audioInitialState={{ controls: true, preload: 'none', curPlayId: 1 }}` and confirm the `<audio>` element receives those attrs
- [ ] React DevTools profiler — onTimeUpdate ticks should not re-render PlayBtn / RepeatTypeBtn / VolumeTriggerBtn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Comments" section to code-naming guidance; README and changelog updated for root class name.

* **New / Improved**
  * More reliable audio playback: deterministic seek-sync, ratio clamping, refined repeat/end behavior, play-on-mount and volume synchronization, and a simplified/flatter playback state and audio-attribute passthrough.

* **Tests**
  * New and updated tests for audio hook, waveform/progress sync, repeat/end flows, provider/context behavior, and transition callback timing.

* **Breaking Changes**
  * Root CSS class renamed to rmap-player-provider (update selectors/tests accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->