### PR TITLE
🐛 fix(speed-selector): group role + close on select

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # React-modern-audio-player
 
+## v2.3.2 (Unreleased)
+
+### ♿ Accessibility
+
+- **`AudioPlayer.SpeedSelector` menu semantics & close-on-select** (Closes [#59](https://github.com/slash9494/react-modern-audio-player/issues/59)): the speed dropdown now exposes its options as a labelled `role="group"` of `aria-pressed` toggle buttons instead of `role="menu"` / `role="menuitemradio"` + `aria-checked`, and selecting a rate now closes the dropdown. The original `role="menu"` contract implied full WAI-ARIA APG keyboard navigation (arrow keys, `Home`/`End`, `Esc`) that was never implemented; the toggle-button group is fully operable with native `Tab` + `Enter`/`Space` and carries no unmet keyboard expectation. This changes the rendered ARIA tree only — no public props, types, or runtime behavior (rate selection still dispatches `SET_PLAYBACK_RATE`) changed, so it is not a breaking API change.
+
 ## v2.3.1 (2026-05-01)
 
 ### 🐛 Bug Fixes

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ♿ Accessibility
 
-- **`AudioPlayer.SpeedSelector` menu semantics & close-on-select** (Closes [#59](https://github.com/slash9494/react-modern-audio-player/issues/59)): the speed dropdown now exposes its options as a labelled `role="group"` of `aria-pressed` toggle buttons instead of `role="menu"` / `role="menuitemradio"` + `aria-checked`, and selecting a rate now closes the dropdown. The original `role="menu"` contract implied full WAI-ARIA APG keyboard navigation (arrow keys, `Home`/`End`, `Esc`) that was never implemented; the toggle-button group is fully operable with native `Tab` + `Enter`/`Space` and carries no unmet keyboard expectation. This changes the rendered ARIA tree only — no public props, types, or runtime behavior (rate selection still dispatches `SET_PLAYBACK_RATE`) changed, so it is not a breaking API change.
+- **`AudioPlayer.SpeedSelector` menu semantics & close-on-select** (Closes [#59](https://github.com/slash9494/react-modern-audio-player/issues/59)): the speed dropdown now exposes its options as a labelled `role="group"` of `aria-pressed` toggle buttons instead of `role="menu"` / `role="menuitemradio"` + `aria-checked`, and selecting a rate now closes the dropdown. The original `role="menu"` contract implied full WAI-ARIA APG keyboard navigation (arrow keys, `Home`/`End`, `Esc`) that was never implemented; the toggle-button group is fully operable with native `Tab` + `Enter`/`Space` and carries no unmet keyboard expectation.
 
 ## v2.3.1 (2026-05-01)
 

--- a/package/src/components/AudioPlayer/Interface/Controller/SpeedSelector/SpeedSelector.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/SpeedSelector/SpeedSelector.tsx
@@ -1,10 +1,11 @@
-import { FC, memo, useCallback, useRef } from "react";
+import { FC, memo, useCallback, useRef, MouseEvent } from "react";
 import "./SpeedSelector.css";
 import Dropdown from "@/components/Dropdown";
 import Grid, { GridItemLayoutProps } from "@/components/Grid";
 import { SpeedSelectorPlacement } from "@/components/AudioPlayer/Context/StateContext";
 import { useNonNullableContext } from "@/hooks/useNonNullableContext";
 import { audioPlayerDispatchContext } from "@/components/AudioPlayer/Context/dispatchContext";
+import { dropdownContext } from "@/components/Dropdown/DropdownContext";
 import { usePlaybackContext } from "@/components/AudioPlayer/Context/hooks/usePlaybackContext";
 import { useUIContext } from "@/components/AudioPlayer/Context/hooks/useUIContext";
 import { useResolvedGridArea } from "../../hooks/useResolvedGridArea";
@@ -15,6 +16,58 @@ const DEFAULT_PLAYBACK_RATE_OPTIONS = [
 ] as const;
 
 const formatPlaybackRate = (rate: number): string => `${rate}×`;
+
+interface SpeedSelectorMenuProps {
+  rateOptions: readonly number[];
+  playbackRate: number;
+  formatRateLabel: (rate: number) => string;
+}
+
+const SpeedSelectorMenu: FC<SpeedSelectorMenuProps> = ({
+  rateOptions,
+  playbackRate,
+  formatRateLabel,
+}) => {
+  const audioPlayerDispatch = useNonNullableContext(audioPlayerDispatchContext);
+  const { setIsOpen } = useNonNullableContext(dropdownContext);
+
+  const handleSelectRate = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      const rate = Number(event.currentTarget.dataset.rate);
+      audioPlayerDispatch({ type: "SET_PLAYBACK_RATE", playbackRate: rate });
+      setIsOpen(false);
+    },
+    [audioPlayerDispatch, setIsOpen]
+  );
+
+  return (
+    <div
+      role="group"
+      aria-label="Playback speed"
+      className="rmap-speed-selector-menu"
+    >
+      {rateOptions.map((rate) => {
+        const isActive = rate === playbackRate;
+        const optionClassName = isActive
+          ? "rmap-speed-selector-option rmap-speed-selector-option--active"
+          : "rmap-speed-selector-option";
+        return (
+          <button
+            key={rate}
+            type="button"
+            aria-pressed={isActive}
+            className={optionClassName}
+            data-testid="speed-selector-option"
+            data-rate={rate}
+            onClick={handleSelectRate}
+          >
+            {formatRateLabel(rate)}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
 
 export interface SpeedSelectorProps extends GridItemLayoutProps {
   options?: number[];
@@ -35,9 +88,6 @@ export const SpeedSelector: FC<SpeedSelectorProps> = memo(
   }) {
     const triggerRef = useRef<HTMLButtonElement>(null);
     const { playbackRate } = usePlaybackContext();
-    const audioPlayerDispatch = useNonNullableContext(
-      audioPlayerDispatchContext
-    );
     const { speedSelectorPlacement: contextSpeedSelectorPlacement } =
       useUIContext();
 
@@ -53,13 +103,6 @@ export const SpeedSelector: FC<SpeedSelectorProps> = memo(
         triggerRef,
         defaults: { triggerType: "click", placement: "top" },
       });
-
-    const handleSelectRate = useCallback(
-      (rate: number) => {
-        audioPlayerDispatch({ type: "SET_PLAYBACK_RATE", playbackRate: rate });
-      },
-      [audioPlayerDispatch]
-    );
 
     return (
       <Grid.Item
@@ -84,33 +127,11 @@ export const SpeedSelector: FC<SpeedSelectorProps> = memo(
             {formatRateLabel(playbackRate)}
           </Dropdown.Trigger>
           <Dropdown.Content>
-            <ul
-              role="menu"
-              aria-label="Playback speed"
-              className="rmap-speed-selector-menu"
-            >
-              {rateOptions.map((rate) => {
-                const isActive = rate === playbackRate;
-                const optionClassName = isActive
-                  ? "rmap-speed-selector-option rmap-speed-selector-option--active"
-                  : "rmap-speed-selector-option";
-                return (
-                  <li key={rate} role="none">
-                    <button
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={isActive}
-                      className={optionClassName}
-                      data-testid="speed-selector-option"
-                      data-rate={rate}
-                      onClick={() => handleSelectRate(rate)}
-                    >
-                      {formatRateLabel(rate)}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
+            <SpeedSelectorMenu
+              rateOptions={rateOptions}
+              playbackRate={playbackRate}
+              formatRateLabel={formatRateLabel}
+            />
           </Dropdown.Content>
         </Dropdown>
       </Grid.Item>

--- a/package/src/components/AudioPlayer/Interface/Controller/SpeedSelector/__tests__/SpeedSelector.a11y.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/SpeedSelector/__tests__/SpeedSelector.a11y.test.tsx
@@ -137,27 +137,27 @@ describe("SpeedSelector accessibility", () => {
     );
   });
 
-  it("opens the menu on trigger click and exposes role=menu with menuitemradio options", () => {
+  it("opens the menu on trigger click and exposes role=group with aria-pressed toggle options", () => {
     renderSpeedSelector({ playbackRate: 1 });
-    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByRole("group", { name: "Playback speed" })).toBeNull();
 
     openMenuByClickingTrigger();
 
-    const menu = screen.getByRole("menu", { name: "Playback speed" });
+    const menu = screen.getByRole("group", { name: "Playback speed" });
     expect(menu).toBeInTheDocument();
-    const options = screen.getAllByRole("menuitemradio");
+    const options = screen.getAllByTestId("speed-selector-option");
     // Default option set: 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2 — 7 entries.
     expect(options).toHaveLength(7);
   });
 
-  it("active option has aria-checked=true and all others aria-checked=false", () => {
+  it("active option has aria-pressed=true and all others aria-pressed=false", () => {
     renderSpeedSelector({ playbackRate: 1 });
     openMenuByClickingTrigger();
 
-    const options = screen.getAllByRole("menuitemradio");
+    const options = screen.getAllByTestId("speed-selector-option");
     const checkedStates = options.map((opt) => ({
       rate: opt.getAttribute("data-rate"),
-      checked: opt.getAttribute("aria-checked"),
+      checked: opt.getAttribute("aria-pressed"),
     }));
     expect(checkedStates).toEqual([
       { rate: "0.5", checked: "false" },
@@ -175,7 +175,7 @@ describe("SpeedSelector accessibility", () => {
     openMenuByClickingTrigger();
 
     const optionForOnePointFive = screen
-      .getAllByRole("menuitemradio")
+      .getAllByTestId("speed-selector-option")
       .find((el) => el.getAttribute("data-rate") === "1.5");
     if (!optionForOnePointFive) throw new Error("expected 1.5x option");
 
@@ -189,19 +189,63 @@ describe("SpeedSelector accessibility", () => {
     });
   });
 
-  it("uses the active option's aria-checked when playbackRate matches a non-default option", () => {
+  it("closes the dropdown after selecting an option (content unmounts)", () => {
+    renderSpeedSelector({ playbackRate: 1 });
+    openMenuByClickingTrigger();
+    expect(
+      screen.getByRole("group", { name: "Playback speed" })
+    ).toBeInTheDocument();
+
+    const optionForTwo = screen
+      .getAllByTestId("speed-selector-option")
+      .find((el) => el.getAttribute("data-rate") === "2");
+    if (!optionForTwo) throw new Error("expected 2x option");
+    act(() => {
+      fireEvent.click(optionForTwo);
+    });
+    // Drive the Dropdown exit transition (setIsOpen(false) → CssTransition
+    // leave timer → content unmount) to completion.
+    act(() => vi.runAllTimers());
+    act(() => vi.runAllTimers());
+
+    expect(screen.queryByRole("group", { name: "Playback speed" })).toBeNull();
+  });
+
+  it("trigger exposes aria-haspopup and toggles aria-expanded across the open/close lifecycle", () => {
+    renderSpeedSelector({ playbackRate: 1 });
+    const trigger = screen.getByTestId("speed-selector-trigger");
+    expect(trigger).toHaveAttribute("aria-haspopup", "true");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    openMenuByClickingTrigger();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    const optionForHalf = screen
+      .getAllByTestId("speed-selector-option")
+      .find((el) => el.getAttribute("data-rate") === "0.5");
+    if (!optionForHalf) throw new Error("expected 0.5x option");
+    act(() => {
+      fireEvent.click(optionForHalf);
+    });
+    act(() => vi.runAllTimers());
+    act(() => vi.runAllTimers());
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("uses the active option's aria-pressed when playbackRate matches a non-default option", () => {
     renderSpeedSelector({ playbackRate: 1.75 });
     openMenuByClickingTrigger();
 
-    const options = screen.getAllByRole("menuitemradio");
+    const options = screen.getAllByTestId("speed-selector-option");
     const active = options.find(
-      (opt) => opt.getAttribute("aria-checked") === "true"
+      (opt) => opt.getAttribute("aria-pressed") === "true"
     );
     if (!active) throw new Error("expected one active option");
     expect(active.getAttribute("data-rate")).toBe("1.75");
     // Exactly one active option at any time.
     expect(
-      options.filter((opt) => opt.getAttribute("aria-checked") === "true")
+      options.filter((opt) => opt.getAttribute("aria-pressed") === "true")
     ).toHaveLength(1);
   });
 
@@ -209,7 +253,7 @@ describe("SpeedSelector accessibility", () => {
     renderSpeedSelector({ playbackRate: 1, options: [1, 2] });
     openMenuByClickingTrigger();
 
-    const options = screen.getAllByRole("menuitemradio");
+    const options = screen.getAllByTestId("speed-selector-option");
     expect(options).toHaveLength(2);
     expect(options.map((opt) => opt.getAttribute("data-rate"))).toEqual([
       "1",
@@ -229,7 +273,7 @@ describe("SpeedSelector accessibility", () => {
     expect(trigger).toHaveTextContent("1x");
 
     openMenuByClickingTrigger();
-    const options = screen.getAllByRole("menuitemradio");
+    const options = screen.getAllByTestId("speed-selector-option");
     expect(options.map((opt) => opt.textContent)).toEqual([
       "0.5x",
       "0.75x",
@@ -259,7 +303,9 @@ describe("SpeedSelector accessibility", () => {
     const { container } = renderSpeedSelector({ playbackRate: 1 });
     openMenuByClickingTrigger();
     // Confirm the menu is committed before scanning.
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Playback speed" })
+    ).toBeInTheDocument();
     // Flush any pending fake timers first to avoid leaking scheduled work
     // across the timer-mode boundary.
     act(() => {
@@ -277,7 +323,7 @@ describe("SpeedSelector accessibility", () => {
     openMenuByClickingTrigger();
 
     const optionForHalf = screen
-      .getAllByRole("menuitemradio")
+      .getAllByTestId("speed-selector-option")
       .find((el) => el.getAttribute("data-rate") === "0.5");
     if (!optionForHalf) throw new Error("expected 0.5x option");
     act(() => {
@@ -298,12 +344,12 @@ describe("SpeedSelector accessibility", () => {
 
   it('triggerType="hover" opens the menu on mouseEnter', () => {
     renderSpeedSelector({ playbackRate: 1, triggerType: "hover" });
-    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByRole("group", { name: "Playback speed" })).toBeNull();
 
     openMenuByHoveringTrigger();
 
     expect(
-      screen.getByRole("menu", { name: "Playback speed" })
+      screen.getByRole("group", { name: "Playback speed" })
     ).toBeInTheDocument();
   });
 
@@ -321,7 +367,7 @@ describe("SpeedSelector accessibility", () => {
     act(() => vi.runAllTimers());
     act(() => vi.runAllTimers());
 
-    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByRole("group", { name: "Playback speed" })).toBeNull();
   });
 
   // --- placement prop & UIContext fallback --------------------------------
@@ -331,7 +377,7 @@ describe("SpeedSelector accessibility", () => {
   // `<ul role="menu">` is a direct child of that styled <div>, so reading
   // `menu.parentElement.style` reflects the resolved placement deterministically.
   const getMenuPlacementStyle = (): CSSStyleDeclaration => {
-    const menu = screen.getByRole("menu", { name: "Playback speed" });
+    const menu = screen.getByRole("group", { name: "Playback speed" });
     const contentEl = menu.parentElement;
     if (!contentEl) throw new Error("expected menu to have a content parent");
     return contentEl.style;


### PR DESCRIPTION
## Summary

Resolves the deferred a11y gaps in `AudioPlayer.SpeedSelector` (issue #59, follow-up to PR #58). The dropdown previously declared `role="menu"` / `role="menuitemradio"` but never implemented the WAI-ARIA APG menu keyboard contract (arrow keys / Home / End / Esc), so the ARIA role over-promised. Rather than build the keyboard layer, the contract is **lowered** to a labelled `role="group"` of `aria-pressed` toggle buttons — fully operable with native Tab + Enter/Space and carrying no unmet keyboard expectation.

## Changes

- **gap #2 (role lowering)**: `role="menu"`/`menuitemradio`/`aria-checked` → `<div role="group">` + `aria-pressed` toggle buttons (`<ul>`→`<div>` avoids the axe `listitem` orphan; CSS unaffected)
- **gap #1 (close-on-select)**: selecting a rate now closes the dropdown via `setIsOpen(false)`; the option list moves into a small `SpeedSelectorMenu` child that consumes `dropdownContext` (required since `SpeedSelector` renders above the provider)
- **gap #3 (inline closure)**: single stable handler reading `data-rate` from `event.currentTarget.dataset`
- **gap #4 (tests)**: a11y test queries updated to group/aria-pressed; added close-on-select + aria-expanded/haspopup lifecycle tests
- CHANGELOG: `v2.3.2 (Unreleased) ♿ Accessibility` — documented as non-breaking (ARIA tree only; props/types/dispatch behavior unchanged)

## Test Results

- [x] build passes (tsc --noEmit EXIT=0)
- [x] lint passes (pre-commit lint-staged)
- [x] tests pass (full suite 315; SpeedSelector a11y 19)

## Related Issues

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Updated the playback speed selector’s semantics: speed options are now exposed as a labeled `role="group"` of `aria-pressed` toggle buttons (instead of menu/menuitem radio semantics).
  * Selecting a speed now closes the dropdown while maintaining the same rate selection behavior.
* **Bug Fixes**
  * Fixed/updated accessibility state and open/close behavior so the announced selection matches the UI across default and non-default playback rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->