### PR TITLE
🧪 test: fix contradictory and non-conformant tests

### DIFF
--- a/agents/base/unit.md
+++ b/agents/base/unit.md
@@ -47,7 +47,7 @@ SET_REPEAT_TYPE
 UPDATE_PLAY_LIST
 
 - valid: updates playList and recalculates curIdx
-- invalid (curPlayId not found): returns current state unchanged, logs error
+- curPlayId not found in new list: resets to first track (curPlayId/curIdx → first item, bumps audioResetKey, currentTime 0)
 
 SET_VOLUME / SET_MUTED
 

--- a/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
+++ b/package/src/components/AudioPlayer/Audio/__tests__/useAudio.test.tsx
@@ -112,7 +112,7 @@ describe("useAudio seek sync effect", () => {
 
     expect(audioEl.currentTime).toBe(60);
     expect(waveformSeekTo).toHaveBeenCalledTimes(1);
-    expect(waveformSeekTo).toHaveBeenCalledWith(60 / TRACK_DURATION_SEC);
+    expect(waveformSeekTo).toHaveBeenCalledWith(1 / 3);
   });
 
   it("does NOT write audioEl.currentTime when seekRequestKey is 0, even when playbackCurrentTime is far from DOM (stale onTimeUpdate echo scenario)", () => {
@@ -315,7 +315,7 @@ describe("useAudio seek sync effect — rerender behavior", () => {
     rerender(<Harness playbackCurrentTime={90} seekRequestKey={2} />);
     expect(audioEl.currentTime).toBe(90);
     expect(waveformSeekTo).toHaveBeenCalledTimes(2);
-    expect(waveformSeekTo).toHaveBeenLastCalledWith(90 / TRACK_DURATION_SEC);
+    expect(waveformSeekTo).toHaveBeenLastCalledWith(0.5);
   });
 });
 

--- a/package/src/components/AudioPlayer/Container/AudioPlayerContainer.tsx
+++ b/package/src/components/AudioPlayer/Container/AudioPlayerContainer.tsx
@@ -56,6 +56,7 @@ export const AudioPlayerContainer = React.memo<
 
   return (
     <div
+      data-testid="player-provider"
       {...rootContainerProps}
       className={`rmap-player-provider${
         rootContainerProps?.className ? ` ${rootContainerProps.className}` : ""

--- a/package/src/components/AudioPlayer/Interface/index.tsx
+++ b/package/src/components/AudioPlayer/Interface/index.tsx
@@ -39,7 +39,11 @@ export const Interface: FC<InterfaceProps> = ({ children }) => {
       <playListPortalContext.Provider value={portalNode}>
         <playListEmptyContext.Provider value={playListEmptyNode}>
           {playListPlacement === "top" && (
-            <div ref={setPortalNode} className="rmap-sortable-playlist" />
+            <div
+              ref={setPortalNode}
+              className="rmap-sortable-playlist"
+              data-testid="sortable-playlist"
+            />
           )}
           <Grid
             alignItems="center"
@@ -48,6 +52,7 @@ export const Interface: FC<InterfaceProps> = ({ children }) => {
             minHeight="30px"
             columns={gridColumns}
             UNSAFE_className="rmap-interface-grid"
+            data-testid="interface-grid"
           >
             <Information />
             <Controller />
@@ -55,7 +60,11 @@ export const Interface: FC<InterfaceProps> = ({ children }) => {
             {compoundChildren}
           </Grid>
           {playListPlacement === "bottom" && (
-            <div ref={setPortalNode} className="rmap-sortable-playlist" />
+            <div
+              ref={setPortalNode}
+              className="rmap-sortable-playlist"
+              data-testid="sortable-playlist"
+            />
           )}
         </playListEmptyContext.Provider>
       </playListPortalContext.Provider>

--- a/package/src/components/AudioPlayer/Provider/__tests__/context-isolation.test.tsx
+++ b/package/src/components/AudioPlayer/Provider/__tests__/context-isolation.test.tsx
@@ -162,12 +162,14 @@ describe("playbackContext isolation", () => {
     expect(after.resourceCount - base.resourceCount).toBe(0);
   });
 
-  it("SET_VOLUME only re-renders playback consumers", () => {
+  it("SET_PLAYBACK_RATE only re-renders playback consumers", () => {
     const probes = makeProbes();
     const dispatch = renderIsolated(<AllProbes {...probes} />);
     const base = probes.snapshot();
 
-    act(() => dispatch.current({ type: "SET_VOLUME", volume: 0.5 }));
+    act(() =>
+      dispatch.current({ type: "SET_PLAYBACK_RATE", playbackRate: 1.5 })
+    );
 
     const after = probes.snapshot();
     expect(after.playbackCount - base.playbackCount).toBe(1);

--- a/package/src/components/Drawer/__tests__/Drawer.a11y.test.tsx
+++ b/package/src/components/Drawer/__tests__/Drawer.a11y.test.tsx
@@ -29,7 +29,7 @@ const DrawerWrapper = ({
 describe("DrawerContent accessibility", () => {
   it('has role="dialog" when open', () => {
     render(<DrawerWrapper initialOpen={true} />);
-    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
   it('has aria-modal="true"', () => {

--- a/package/src/components/Grid/Grid.tsx
+++ b/package/src/components/Grid/Grid.tsx
@@ -7,6 +7,7 @@ export interface NativeGridProps {
   justifyContent?: CSSProperties["justifyContent"];
   minHeight?: CSSProperties["minHeight"];
   UNSAFE_className?: string;
+  "data-testid"?: string;
   children?: ReactNode;
 }
 
@@ -17,6 +18,7 @@ const NativeGrid: FC<NativeGridProps> = ({
   justifyContent,
   minHeight,
   UNSAFE_className,
+  "data-testid": testId,
   children,
 }) => {
   const style: CSSProperties = {
@@ -28,7 +30,7 @@ const NativeGrid: FC<NativeGridProps> = ({
     minHeight,
   };
   return (
-    <div className={UNSAFE_className} style={style}>
+    <div className={UNSAFE_className} style={style} data-testid={testId}>
       {children}
     </div>
   );

--- a/package/src/components/icons/__tests__/icons.test.tsx
+++ b/package/src/components/icons/__tests__/icons.test.tsx
@@ -17,9 +17,24 @@ import {
 import type { SvgIconProps } from "@/components/icons";
 import { FC } from "react";
 
+const allIcons: [string, FC<SvgIconProps>][] = [
+  ["MdPlayCircleFilled", MdPlayCircleFilled],
+  ["MdPauseCircleFilled", MdPauseCircleFilled],
+  ["MdPlaylistPlay", MdPlaylistPlay],
+  ["TbRepeat", TbRepeat],
+  ["TbRepeatOnce", TbRepeatOnce],
+  ["TbRepeatOff", TbRepeatOff],
+  ["TbArrowsShuffle", TbArrowsShuffle],
+  ["TbVolume", TbVolume],
+  ["TbVolume2", TbVolume2],
+  ["TbVolume3", TbVolume3],
+  ["ImPrevious", ImPrevious],
+  ["ImNext", ImNext],
+];
+
 describe("size prop", () => {
-  it("default → height/width 1em", () => {
-    const { container } = render(<MdPlayCircleFilled />);
+  it.each(allIcons)("%s default → height/width 1em", (_name, Icon) => {
+    const { container } = render(<Icon />);
     const svg = container.querySelector("svg")!;
     expect(svg.getAttribute("height")).toBe("1em");
     expect(svg.getAttribute("width")).toBe("1em");
@@ -85,21 +100,6 @@ describe("SVGProps forwarding", () => {
     expect(svg.getAttribute("aria-hidden")).toBe("false");
   });
 });
-
-const allIcons: [string, FC<SvgIconProps>][] = [
-  ["MdPlayCircleFilled", MdPlayCircleFilled],
-  ["MdPauseCircleFilled", MdPauseCircleFilled],
-  ["MdPlaylistPlay", MdPlaylistPlay],
-  ["TbRepeat", TbRepeat],
-  ["TbRepeatOnce", TbRepeatOnce],
-  ["TbRepeatOff", TbRepeatOff],
-  ["TbArrowsShuffle", TbArrowsShuffle],
-  ["TbVolume", TbVolume],
-  ["TbVolume2", TbVolume2],
-  ["TbVolume3", TbVolume3],
-  ["ImPrevious", ImPrevious],
-  ["ImNext", ImNext],
-];
 
 describe("smoke — all 12 icons render svg", () => {
   it.each(allIcons)("%s renders an svg element", (_name, Icon) => {

--- a/package/src/components/icons/__tests__/icons.test.tsx
+++ b/package/src/components/icons/__tests__/icons.test.tsx
@@ -17,40 +17,14 @@ import {
 import type { SvgIconProps } from "@/components/icons";
 import { FC } from "react";
 
-describe("SVG icon defaults — MdPlayCircleFilled", () => {
-  it('aria-hidden="true"', () => {
-    const { container } = render(<MdPlayCircleFilled />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("aria-hidden")).toBe("true");
-  });
-
-  it('focusable="false"', () => {
-    const { container } = render(<MdPlayCircleFilled />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("focusable")).toBe("false");
-  });
-
-  it('default size → height/width "1em"', () => {
+describe("size prop", () => {
+  it("default → height/width 1em", () => {
     const { container } = render(<MdPlayCircleFilled />);
     const svg = container.querySelector("svg")!;
     expect(svg.getAttribute("height")).toBe("1em");
     expect(svg.getAttribute("width")).toBe("1em");
   });
 
-  it('viewBox="0 0 24 24"', () => {
-    const { container } = render(<MdPlayCircleFilled />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("viewBox")).toBe("0 0 24 24");
-  });
-
-  it("no style.color when color prop absent", () => {
-    const { container } = render(<MdPlayCircleFilled />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.style.color).toBe("");
-  });
-});
-
-describe("size prop", () => {
   it("numeric size → height/width as string", () => {
     const { container } = render(<MdPlayCircleFilled size={24} />);
     const svg = container.querySelector("svg")!;
@@ -112,64 +86,33 @@ describe("SVGProps forwarding", () => {
   });
 });
 
-describe("Tb icon defaults — TbRepeat", () => {
-  it('aria-hidden="true"', () => {
-    const { container } = render(<TbRepeat />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("aria-hidden")).toBe("true");
-  });
-
-  it('focusable="false"', () => {
-    const { container } = render(<TbRepeat />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("focusable")).toBe("false");
-  });
-
-  it('fill="none"', () => {
-    const { container } = render(<TbRepeat />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("fill")).toBe("none");
-  });
-
-  it('strokeWidth="2"', () => {
-    const { container } = render(<TbRepeat />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("stroke-width")).toBe("2");
-  });
-});
-
-describe("Im icon defaults — ImPrevious", () => {
-  it('aria-hidden="true"', () => {
-    const { container } = render(<ImPrevious />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("aria-hidden")).toBe("true");
-  });
-
-  it('viewBox="0 0 16 16"', () => {
-    const { container } = render(<ImPrevious />);
-    const svg = container.querySelector("svg")!;
-    expect(svg.getAttribute("viewBox")).toBe("0 0 16 16");
-  });
-});
+const allIcons: [string, FC<SvgIconProps>][] = [
+  ["MdPlayCircleFilled", MdPlayCircleFilled],
+  ["MdPauseCircleFilled", MdPauseCircleFilled],
+  ["MdPlaylistPlay", MdPlaylistPlay],
+  ["TbRepeat", TbRepeat],
+  ["TbRepeatOnce", TbRepeatOnce],
+  ["TbRepeatOff", TbRepeatOff],
+  ["TbArrowsShuffle", TbArrowsShuffle],
+  ["TbVolume", TbVolume],
+  ["TbVolume2", TbVolume2],
+  ["TbVolume3", TbVolume3],
+  ["ImPrevious", ImPrevious],
+  ["ImNext", ImNext],
+];
 
 describe("smoke — all 12 icons render svg", () => {
-  const allIcons: [string, FC<SvgIconProps>][] = [
-    ["MdPlayCircleFilled", MdPlayCircleFilled],
-    ["MdPauseCircleFilled", MdPauseCircleFilled],
-    ["MdPlaylistPlay", MdPlaylistPlay],
-    ["TbRepeat", TbRepeat],
-    ["TbRepeatOnce", TbRepeatOnce],
-    ["TbRepeatOff", TbRepeatOff],
-    ["TbArrowsShuffle", TbArrowsShuffle],
-    ["TbVolume", TbVolume],
-    ["TbVolume2", TbVolume2],
-    ["TbVolume3", TbVolume3],
-    ["ImPrevious", ImPrevious],
-    ["ImNext", ImNext],
-  ];
-
   it.each(allIcons)("%s renders an svg element", (_name, Icon) => {
     const { container } = render(<Icon />);
     expect(container.querySelector("svg")).not.toBeNull();
+  });
+});
+
+describe("decorative a11y defaults — all icons hidden from AT", () => {
+  it.each(allIcons)("%s is aria-hidden and not focusable", (_name, Icon) => {
+    const { container } = render(<Icon />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("aria-hidden")).toBe("true");
+    expect(svg.getAttribute("focusable")).toBe("false");
   });
 });

--- a/package/src/ui/__tests__/CssTransition.test.tsx
+++ b/package/src/ui/__tests__/CssTransition.test.tsx
@@ -90,7 +90,9 @@ describe("CssTransition latest-ref callback handling", () => {
       </CssTransition>
     );
 
-    vi.advanceTimersByTime(25);
+    act(() => {
+      vi.advanceTimersByTime(25);
+    });
 
     expect(firstExitCallback).not.toHaveBeenCalled();
     expect(replacedExitCallback).toHaveBeenCalledTimes(1);

--- a/storybook/src/App.test.tsx
+++ b/storybook/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/test/e2e/play-pause.spec.ts
+++ b/test/e2e/play-pause.spec.ts
@@ -8,6 +8,9 @@ test.describe("Play / Pause toggle", () => {
     await playBtn.click();
     await expect(playBtn).toBeVisible();
 
+    // Playing → button switches to the pause icon (aria-label "Pause")
+    await expect(playBtn).toHaveAttribute("aria-label", "Pause");
+
     // Wait until current time advances past 00:00
     await expect
       .poll(() => trackCurrentTime.textContent(), { timeout: 10000 })

--- a/test/e2e/progress-switch.spec.ts
+++ b/test/e2e/progress-switch.spec.ts
@@ -36,7 +36,7 @@ test.describe("Progress mode switching (e2e)", () => {
     });
 
     // Switch to waveform via in-page button (NOT page reload)
-    await page.getByRole("button", { name: "progress type" }).click();
+    await page.getByTestId("rmap-toggle-progress-type").click();
 
     // Wait for waveform to init
     const wave = page.locator("#rm-waveform wave").first();
@@ -154,7 +154,7 @@ test.describe("Progress mode switching (e2e)", () => {
       .toBeGreaterThan(2);
 
     // Switch to waveform while playing
-    await page.getByRole("button", { name: "progress type" }).click();
+    await page.getByTestId("rmap-toggle-progress-type").click();
     const wave = page.locator("#rm-waveform wave").first();
     await expect(wave).toBeVisible({ timeout: 10000 });
 
@@ -215,7 +215,7 @@ test.describe("Progress mode switching (e2e)", () => {
     });
 
     // Switch to waveform while still playing
-    await page.getByRole("button", { name: "progress type" }).click();
+    await page.getByTestId("rmap-toggle-progress-type").click();
     const wave = page.locator("#rm-waveform wave").first();
     await expect(wave).toBeVisible({ timeout: 10000 });
 
@@ -232,10 +232,15 @@ test.describe("Progress mode switching (e2e)", () => {
       .toBeGreaterThan(timeBefore);
 
     // Audio should still be playing
-    const isPlaying = await page.evaluate(() => {
-      const audio = document.querySelector("audio");
-      return audio ? !audio.paused : false;
-    });
-    expect(isPlaying).toBe(true);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const audio = document.querySelector("audio");
+            return audio ? !audio.paused : false;
+          }),
+        { timeout: 3000 }
+      )
+      .toBe(true);
   });
 });

--- a/test/e2e/ui-placement.spec.ts
+++ b/test/e2e/ui-placement.spec.ts
@@ -3,7 +3,7 @@ import type { Locator } from "@playwright/test";
 
 test.describe("PlayerPlacement — position", () => {
   test("static (default) → position is not fixed", async ({ playerPage }) => {
-    const provider = playerPage.page.locator(".rmap-player-provider");
+    const provider = playerPage.page.getByTestId("player-provider");
     const position = await provider.evaluate(
       (el) => getComputedStyle(el).position
     );
@@ -27,7 +27,7 @@ test.describe("PlayerPlacement — position", () => {
       playerPageLazy,
     }) => {
       await playerPageLazy.gotoWithConfig({ playerPlacement: placement });
-      const provider = playerPageLazy.page.locator(".rmap-player-provider");
+      const provider = playerPageLazy.page.getByTestId("player-provider");
 
       const position = await provider.evaluate(
         (el) => getComputedStyle(el).position
@@ -166,8 +166,8 @@ test.describe("PlayListPlacement — DOM order", () => {
     playerPage,
   }) => {
     const isBottomPlacement = await playerPage.page.evaluate(() => {
-      const list = document.querySelector(".rmap-sortable-playlist");
-      const grid = document.querySelector(".rmap-interface-grid");
+      const list = document.querySelector('[data-testid="sortable-playlist"]');
+      const grid = document.querySelector('[data-testid="interface-grid"]');
       if (!list || !grid) return null;
       // DOCUMENT_POSITION_FOLLOWING means grid comes before list in DOM
       return Boolean(
@@ -183,8 +183,8 @@ test.describe("PlayListPlacement — DOM order", () => {
     await playerPageLazy.gotoWithConfig({ playListPlacement: "top" });
 
     const isTopPlacement = await playerPageLazy.page.evaluate(() => {
-      const list = document.querySelector(".rmap-sortable-playlist");
-      const grid = document.querySelector(".rmap-interface-grid");
+      const list = document.querySelector('[data-testid="sortable-playlist"]');
+      const grid = document.querySelector('[data-testid="interface-grid"]');
       if (!list || !grid) return null;
       return Boolean(
         list.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING

--- a/test/integration/compound-slots.test.tsx
+++ b/test/integration/compound-slots.test.tsx
@@ -213,8 +213,7 @@ describe("compound slots (additive)", () => {
   });
 
   it("dev-mode warns when compound duplicates a preset", () => {
-    // Warning hook no-ops under production — this assertion would silently pass.
-    expect(process.env.NODE_ENV).not.toBe("production");
+    // Warning hook no-ops under production; this suite relies on Vitest's non-production NODE_ENV.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
       /* suppress */
     });

--- a/test/integration/compound-slots.test.tsx
+++ b/test/integration/compound-slots.test.tsx
@@ -213,7 +213,9 @@ describe("compound slots (additive)", () => {
   });
 
   it("dev-mode warns when compound duplicates a preset", () => {
-    // Warning hook no-ops under production; this suite relies on Vitest's non-production NODE_ENV.
+    // Warning hook no-ops under production; pin a non-production env so this
+    // never silently depends on the ambient NODE_ENV.
+    vi.stubEnv("NODE_ENV", "development");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
       /* suppress */
     });
@@ -232,6 +234,7 @@ describe("compound slots (additive)", () => {
       )
     ).toBe(true);
     warnSpy.mockRestore();
+    vi.unstubAllEnvs();
   });
 });
 


### PR DESCRIPTION
## Summary

Cleans up the existing test suite by fixing cases that were contradictory or
violated the project's testing guidelines (`agents/base/{testing,unit,e2e}.md`).
Findings came from a review of all test files; each fix was verified against the
implementation it depends on.

## Changes

- **docs(testing)**: `unit.md` UPDATE_PLAY_LIST invalid-id spec said "returns
  state unchanged" but the reducer resets to the first track — aligned the spec
  with actual behavior.
- **tautological**: `useAudio` waveform-seek ratios recomputed from the same
  constant as the impl → replaced with independent literals (`1/3`, `0.5`).
- **always-true**: removed CRA-boilerplate `storybook/App.test`, the
  `NODE_ENV !== production` guard in `compound-slots`, and switched
  `Drawer` `toBeDefined` → `toBeInTheDocument`.
- **icons**: dropped static-attribute assertions (viewBox/fill/strokeWidth —
  pure rendering details) while **keeping** prop-contract (size/color/SVGProps)
  and adding a11y-default coverage (aria-hidden/focusable across all 12 icons).
- **race conditions**: wrapped `CssTransition` timer advance in `act()`; e2e
  asserts native `audio.paused` via `expect.poll`.
- **e2e selectors**: replaced CSS-class / accessible-name-text selectors with
  `data-testid` (`player-provider`, `sortable-playlist`, `interface-grid`, and
  the existing `rmap-toggle-progress-type`). Added a `data-testid` passthrough to
  `Grid`; consumer-overridable, no behavior change.
- **coverage**: replaced a duplicate `SET_VOLUME` context-isolation test with
  `SET_PLAYBACK_RATE`; `play-pause` e2e now asserts the pause icon via aria-label.

## Test Results

- [x] build passes (typeCheck clean)
- [x] lint passes (pre-commit lint-staged)
- [x] tests pass — unit 280, integration 37, e2e (chromium) for affected specs

## Notes

No user-facing API/props/behavior change → no `README` / `CHANGELOG` update
needed. `data-testid` additions compile into `dist` but are inert, additive DOM
attributes consistent with existing test hooks.

## Related Issues

<!-- none -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The player now resets to the first track when the currently selected track is no longer in an updated playlist, and playback time resets to the start.
  * Playback sync and progress switching behavior were refined to keep the audio state and waveform display consistent.

* **Documentation**
  * Updated expected playlist update behavior in the internal guidance docs.

* **Chores**
  * Improved UI test coverage and selectors for more reliable player, drawer, icon, and transition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->