### PR TITLE
fix(progress): reset waveform fallback mode on track change

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # React-modern-audio-player
 
+## Unreleased
+
+### 🐛 Fixed
+
+- **Waveform fallback stuck after advancing from a long-form/live track**: auto-advancing to the next track (via `onEnded` or the next control) kept `isLoadedMetaData` set, so the progress bar kept reading the previous long-form/live track's duration and stayed on the `faux`/`live` bar fallback until the new track's metadata loaded. `NEXT_AUDIO` now resets `isLoadedMetaData` when the track actually changes, matching the shuffle and previous-track paths, while leaving a single-track repeat-`ALL` loop (same `src`, no reload) untouched so its progress bar stays live.
+
 ## v2.4.1 - 2026-07-21
 
 ### 🐛 Fixed

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,6 +1,6 @@
 # React-modern-audio-player
 
-## Unreleased
+## v2.4.2 (Unreleased)
 
 ### 🐛 Fixed
 

--- a/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
+++ b/package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts
@@ -46,6 +46,39 @@ describe("NEXT_AUDIO", () => {
     expect(next.audioResetKey).toBe(state.audioResetKey + 1);
   });
 
+  it("resets isLoadedMetaData so the new track re-derives its waveform mode", () => {
+    // A long-form/live previous track leaves isLoadedMetaData=true; without a
+    // reset useWaveformMode keeps reading the old audioEl.duration and the
+    // faux/live bar fallback sticks on the next track until loadedmetadata.
+    const base = makeBaseState();
+    const state = {
+      ...base,
+      curIdx: 0,
+      curPlayId: 1,
+      curAudioState: { ...base.curAudioState, isLoadedMetaData: true },
+    };
+    const next = audioPlayerReducer(state, { type: "NEXT_AUDIO" });
+    expect(next.curIdx).toBe(1);
+    expect(next.curAudioState.isLoadedMetaData).toBe(false);
+  });
+
+  it("keeps isLoadedMetaData on a single-track ALL loop (same src never reloads)", () => {
+    // (0+1)%1 === 0: same idx/id/src, so <audio> never reloads and
+    // loadedmetadata cannot re-fire. Flipping isLoadedMetaData=false would
+    // strand it false forever and disable the progress bar.
+    const base = makeBaseState();
+    const state = {
+      ...base,
+      playList: [base.playList[0]],
+      curIdx: 0,
+      curPlayId: base.playList[0].id,
+      curAudioState: { ...base.curAudioState, isLoadedMetaData: true },
+    };
+    const next = audioPlayerReducer(state, { type: "NEXT_AUDIO" });
+    expect(next.curIdx).toBe(0);
+    expect(next.curAudioState.isLoadedMetaData).toBe(true);
+  });
+
   it("wraps around to first track when at end (repeatType ALL)", () => {
     const state = { ...makeBaseState(), curIdx: 2, curPlayId: 3 };
     const next = audioPlayerReducer(state, { type: "NEXT_AUDIO" });

--- a/package/src/components/AudioPlayer/Context/reducer.ts
+++ b/package/src/components/AudioPlayer/Context/reducer.ts
@@ -67,12 +67,20 @@ export const audioPlayerReducer = (
         };
       }
       const infiniteLoopNextIdx = (state.curIdx + 1) % state.playList.length;
+      // Single-track ALL loop returns the same idx/src, so <audio> never
+      // reloads and loadedmetadata never re-fires — flipping isLoadedMetaData
+      // false here would strand it false and kill the progress bar.
+      const isTrackChanging = infiniteLoopNextIdx !== state.curIdx;
       return {
         ...state,
         audioResetKey: state.audioResetKey + 1,
         curIdx: infiniteLoopNextIdx,
         curPlayId: state.playList[infiniteLoopNextIdx].id,
-        curAudioState: { ...state.curAudioState, currentTime: 0 },
+        curAudioState: {
+          ...state.curAudioState,
+          ...(isTrackChanging ? { isLoadedMetaData: false } : {}),
+          currentTime: 0,
+        },
       };
     }
     case "PREV_AUDIO": {


### PR DESCRIPTION
## Summary

In long-form / live playback the progress bar falls back from the waveform to a plain bar (mode `faux` / `live`). Advancing to another track kept that fallback stuck on the new track until its metadata loaded, because `NEXT_AUDIO` did not reset `isLoadedMetaData` — so `useWaveformMode` kept reading the *previous* track's `audioEl.duration`.

The normal next-advance branch was the only track-changing path that skipped this reset; shuffle and previous-track already do it.

## Changes

- `package/src/components/AudioPlayer/Context/reducer.ts`: `NEXT_AUDIO` now resets `isLoadedMetaData` when the track actually changes (index differs). A single-track repeat-`ALL` loop lands on the same idx/id/src — `<audio>` never reloads and `loadedmetadata` never re-fires — so the reset is guarded out there to avoid stranding the flag `false` and disabling the progress bar.
- `package/src/components/AudioPlayer/Context/__tests__/reducer.test.ts`: two cases — reset on real track change, and stay `true` on the single-track `ALL` loop.
- `package/CHANGELOG.md`: fixed entry under `v2.4.2 (Unreleased)`.

## Test Results

- [x] tests pass — full suite 444 passing (`npx vitest run`)
- [x] lint passes (pre-commit lint-staged)
- [x] build unaffected (state-only logic change)

Independent edge-case review (fresh-context agent) flagged the single-track `ALL` loop regression; it is fixed and covered by a regression test above.

## Related Issues

Relates to the long-form / live stream support (v2.4.0, Phase 8.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for long-form audio and live streams with automatic waveform fallback.
  * Added hover and drag time tooltips with edge clamping and configurable top/bottom placement.
  * Added per-track controls for duration, waveform data, live status, and preload behavior.
  * Improved waveform loading feedback with a responsive skeleton and accessible time formatting.

* **Bug Fixes**
  * Prevented stale progress durations when switching tracks.
  * Fixed tooltip clipping near progress bar edges.
  * Improved stability when loading large files and live streams.

* **Documentation**
  * Updated API guidance, examples, naming conventions, and release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->