### PR TITLE
fix(progress): drag-seek beyond the bar + probe cache/dedup cleanups

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -7,10 +7,6 @@
 - **Drag seeking now continues outside the progress bar**: once a seek drag starts, moving the pointer off the bar (or releasing anywhere on the page) is tracked via document-level listeners, so the drag no longer aborts when the cursor leaves the bar. `onMouseLeave` now only clears the hover tooltip.
 - **Oversize probe no longer caches transient failures**: a failed `HEAD` size probe (no response / missing `Content-Length`) is no longer cached permanently, so a later attempt can retry. Successful probes are still cached and deduped, and the probe cache is now bounded.
 
-### 🔄 Changed
-
-- **Reduced redundant work while hovering/seeking the progress bar**: the pointer position is now measured once per mouse event (a single `getBoundingClientRect`) and reused for both the hover tooltip and the seek. Tooltip placement resolution shared by the bar and waveform progress is extracted into a `useTooltipPlacement` hook (no behavior change).
-
 ## v2.4.1 - 2026-07-21
 
 ### 🐛 Fixed

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,16 @@
 # React-modern-audio-player
 
+## v2.4.2 (Unreleased)
+
+### 🐛 Fixed
+
+- **Drag seeking now continues outside the progress bar**: once a seek drag starts, moving the pointer off the bar (or releasing anywhere on the page) is tracked via document-level listeners, so the drag no longer aborts when the cursor leaves the bar. `onMouseLeave` now only clears the hover tooltip.
+- **Oversize probe no longer caches transient failures**: a failed `HEAD` size probe (no response / missing `Content-Length`) is no longer cached permanently, so a later attempt can retry. Successful probes are still cached and deduped, and the probe cache is now bounded.
+
+### 🔄 Changed
+
+- **Reduced redundant work while hovering/seeking the progress bar**: the pointer position is now measured once per mouse event (a single `getBoundingClientRect`) and reused for both the hover tooltip and the seek. Tooltip placement resolution shared by the bar and waveform progress is extracted into a `useTooltipPlacement` hook (no behavior change).
+
 ## v2.4.1 - 2026-07-21
 
 ### 🐛 Fixed

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/BarProgress.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/BarProgress.tsx
@@ -1,24 +1,21 @@
 import { useTimeContext } from "@/components/AudioPlayer/Context/hooks/useTimeContext";
-import { useUIContext } from "@/components/AudioPlayer/Context/hooks/useUIContext";
 import { formatClockTime } from "@/utils/getTime";
 import { safeRatio } from "@/utils/safeRatio";
 import { FC, useRef } from "react";
 import { ProgressTooltip } from "./ProgressTooltip";
-import { useElementWidth, useProgress, useProgressKeyDown } from "./hooks";
-import { useAutoPlacement } from "@/components/AudioPlayer/Interface/hooks";
+import {
+  useElementWidth,
+  useProgress,
+  useProgressKeyDown,
+  useTooltipPlacement,
+} from "./hooks";
 import "./BarProgress.css";
 
 export const BarProgress: FC = () => {
   const { currentTime, duration } = useTimeContext();
-  const { timeTooltipPlacement } = useUIContext();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const wrapperWidth = useElementWidth(wrapperRef);
-  const autoPlacement = useAutoPlacement({
-    triggerRef: wrapperRef,
-    initialState: "top",
-  });
-  const tooltipPlacement =
-    timeTooltipPlacement ?? (autoPlacement === "bottom" ? "bottom" : "top");
+  const tooltipPlacement = useTooltipPlacement(wrapperRef);
 
   const { progressProps, previewRatio, hoverRatio } = useProgress();
   const handleKeyDown = useProgressKeyDown();

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/WaveformProgress.tsx
@@ -1,6 +1,5 @@
 import { usePlaybackContext } from "@/components/AudioPlayer/Context/hooks/usePlaybackContext";
 import { useResourceContext } from "@/components/AudioPlayer/Context/hooks/useResourceContext";
-import { useUIContext } from "@/components/AudioPlayer/Context/hooks/useUIContext";
 import { formatClockTime } from "@/utils/getTime";
 import { FC, useCallback, useEffect, useRef } from "react";
 import { safeRatio } from "@/utils/safeRatio";
@@ -9,10 +8,10 @@ import {
   useElementWidth,
   useProgress,
   useProgressKeyDown,
+  useTooltipPlacement,
   useWaveSurfer,
 } from "./hooks";
 import type { WaveformModeResult } from "./hooks";
-import { useAutoPlacement } from "@/components/AudioPlayer/Interface/hooks";
 import "./WaveformProgress.css";
 
 export const WaveformProgress: FC<{
@@ -24,14 +23,7 @@ export const WaveformProgress: FC<{
   const wrapperWidth = useElementWidth(wrapperRef);
   const { isLoadedMetaData, isPlaying } = usePlaybackContext();
   const { elementRefs } = useResourceContext();
-  const { timeTooltipPlacement } = useUIContext();
-
-  const autoPlacement = useAutoPlacement({
-    triggerRef: wrapperRef,
-    initialState: "top",
-  });
-  const tooltipPlacement =
-    timeTooltipPlacement ?? (autoPlacement === "bottom" ? "bottom" : "top");
+  const tooltipPlacement = useTooltipPlacement(wrapperRef);
 
   const { isWaveformReady } = useWaveSurfer(waveformRef, waveformMode);
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useProgress.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useProgress.test.tsx
@@ -264,6 +264,21 @@ describe("useProgress drag seek debounce", () => {
     expect(audioEl.currentTime).toBe(timeAt(PROGRESS_BAR_WIDTH / 2));
   });
 
+  it("clears the hover tooltip when the drag is released off the bar", () => {
+    vi.useFakeTimers();
+    const audioEl = makeAudioEl(DURATION);
+    const { result } = renderUseProgress(audioEl);
+
+    startDrag(result, PROGRESS_BAR_WIDTH / 4);
+    moveDocumentTo(PROGRESS_BAR_WIDTH + 40);
+    expect(result.current.hoverRatio).toBe(1);
+
+    releaseOnDocument();
+
+    expect(result.current.hoverRatio).toBeNull();
+    expect(result.current.previewRatio).toBeNull();
+  });
+
   it("does not end the drag on mouse leave: it clears hover but a document mousemove still seeks", async () => {
     vi.useFakeTimers();
     const audioEl = makeAudioEl(DURATION);

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useProgress.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useProgress.test.tsx
@@ -5,7 +5,7 @@ import { playbackContext } from "@/components/AudioPlayer/Context/PlaybackContex
 import { resourceContext } from "@/components/AudioPlayer/Context/ResourceContext";
 import { trackContext } from "@/components/AudioPlayer/Context/TrackContext";
 import { AudioData } from "@/components/AudioPlayer/Context";
-import { useProgress } from "../hooks/useProgress";
+import { SEEK_DEBOUNCE_MS, useProgress } from "../hooks/useProgress";
 
 // useProgress.moveAudioTime translates a pointer position on the progress bar
 // into audioEl.currentTime. Live streams must bail out before computing a seek
@@ -17,8 +17,6 @@ import { useProgress } from "../hooks/useProgress";
 
 const PROGRESS_BAR_WIDTH = 200;
 const INITIAL_CURRENT_TIME = 30;
-// Mirrors the module-private SEEK_DEBOUNCE_MS in useProgress.ts (not exported).
-const SEEK_DEBOUNCE_MS = 120;
 
 const makeAudioEl = (duration: number) => {
   const audioEl = document.createElement("audio");
@@ -132,6 +130,26 @@ describe("useProgress drag seek debounce", () => {
     act(() => result.current.progressProps.onMouseMove?.(makeClickAt(clientX)));
   };
 
+  const moveDocumentTo = (clientX: number) => {
+    act(() => {
+      document.dispatchEvent(
+        new window.MouseEvent("mousemove", { clientX, bubbles: true })
+      );
+    });
+  };
+
+  const releaseOnDocument = () => {
+    act(() => {
+      document.dispatchEvent(
+        new window.MouseEvent("mouseup", { bubbles: true })
+      );
+    });
+  };
+
+  const leaveBar = (result: { current: ReturnType<typeof useProgress> }) => {
+    act(() => result.current.progressProps.onMouseLeave?.(makeClickAt(0)));
+  };
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -211,5 +229,57 @@ describe("useProgress drag seek debounce", () => {
     );
 
     expect(audioEl.currentTime).toBe(DURATION / 2);
+  });
+
+  it("keeps seeking from a document mousemove after the pointer leaves the bar", async () => {
+    vi.useFakeTimers();
+    const audioEl = makeAudioEl(DURATION);
+    const { result } = renderUseProgress(audioEl);
+
+    startDrag(result, PROGRESS_BAR_WIDTH / 4);
+    moveDocumentTo(PROGRESS_BAR_WIDTH + 40);
+
+    expect(result.current.previewRatio).toBe(1);
+
+    await act(() => vi.advanceTimersByTimeAsync(SEEK_DEBOUNCE_MS));
+
+    expect(audioEl.currentTime).toBe(DURATION);
+  });
+
+  it("ends the drag on a document mouseup, flushing the pending seek and stopping later moves", async () => {
+    vi.useFakeTimers();
+    const audioEl = makeAudioEl(DURATION);
+    const { result } = renderUseProgress(audioEl);
+
+    startDrag(result, PROGRESS_BAR_WIDTH / 4);
+    moveDocumentTo(PROGRESS_BAR_WIDTH / 2);
+    expect(audioEl.currentTime).toBe(INITIAL_CURRENT_TIME);
+
+    releaseOnDocument();
+    expect(audioEl.currentTime).toBe(timeAt(PROGRESS_BAR_WIDTH / 2));
+
+    moveDocumentTo((PROGRESS_BAR_WIDTH * 3) / 4);
+    await act(() => vi.advanceTimersByTimeAsync(SEEK_DEBOUNCE_MS));
+
+    expect(audioEl.currentTime).toBe(timeAt(PROGRESS_BAR_WIDTH / 2));
+  });
+
+  it("does not end the drag on mouse leave: it clears hover but a document mousemove still seeks", async () => {
+    vi.useFakeTimers();
+    const audioEl = makeAudioEl(DURATION);
+    const { result } = renderUseProgress(audioEl);
+
+    startDrag(result, PROGRESS_BAR_WIDTH / 4);
+    moveDocumentTo(PROGRESS_BAR_WIDTH / 2);
+    expect(result.current.hoverRatio).toBe(ratioAt(PROGRESS_BAR_WIDTH / 2));
+
+    leaveBar(result);
+    expect(result.current.hoverRatio).toBeNull();
+    expect(result.current.previewRatio).toBe(ratioAt(PROGRESS_BAR_WIDTH / 2));
+
+    moveDocumentTo((PROGRESS_BAR_WIDTH * 3) / 4);
+    await act(() => vi.advanceTimersByTimeAsync(SEEK_DEBOUNCE_MS));
+
+    expect(audioEl.currentTime).toBe(timeAt((PROGRESS_BAR_WIDTH * 3) / 4));
   });
 });

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
@@ -428,9 +428,38 @@ describe("useWaveformMode content-length cache lifecycle", () => {
     },
   });
 
-  it("re-probes the same src after a transient failure without a content-length header", async () => {
+  it("caches a header-less 200 verdict and dedupes the HEAD across a remount", async () => {
     global.fetch = vi.fn().mockResolvedValue(makeHeadResponse(null));
-    const track = makeAudioData({ src: "transient-no-length.mp3" });
+    const track = makeAudioData({ src: "headerless-200.mp3" });
+
+    const first = renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+
+    await waitFor(() =>
+      expect(first.result.current.sizeGatePending).toBe(false)
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(first.result.current.mode).toBe("normal");
+
+    const second = renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+
+    await waitFor(() =>
+      expect(second.result.current.sizeGatePending).toBe(false)
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(second.result.current.mode).toBe("normal");
+  });
+
+  it("re-probes the same src after a true transient failure (no response is not cached)", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network"));
+    const track = makeAudioData({ src: "transient-network-error.mp3" });
 
     const first = renderUseWaveformMode({
       playList: [track],

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
@@ -414,6 +414,67 @@ describe("useWaveformMode byte size-gate", () => {
   });
 });
 
+describe("useWaveformMode content-length cache lifecycle", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const makeHeadResponse = (contentLength: string | null) => ({
+    headers: {
+      get: (name: string) => (name === "content-length" ? contentLength : null),
+    },
+  });
+
+  it("re-probes the same src after a transient failure without a content-length header", async () => {
+    global.fetch = vi.fn().mockResolvedValue(makeHeadResponse(null));
+    const track = makeAudioData({ src: "transient-no-length.mp3" });
+
+    const first = renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+
+    await waitFor(() =>
+      expect(first.result.current.sizeGatePending).toBe(false)
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it("shares one in-flight HEAD across concurrent probes of the same src and applies the oversize verdict", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(makeHeadResponse(String(LARGE_FILE_BYTES + 1)));
+    const track = makeAudioData({ src: "dedup-oversize-60mb.flac" });
+
+    const first = renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+    const second = renderUseWaveformMode({
+      playList: [track],
+      curPlayId: track.id,
+      audioEl: makeAudioEl(FINITE_DURATION),
+    });
+
+    await waitFor(() => expect(first.result.current.mode).toBe("faux"));
+    await waitFor(() => expect(second.result.current.mode).toBe("faux"));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("useWaveformMode oversize dev warning", () => {
   const originalFetch = global.fetch;
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/__tests__/useWaveformMode.test.tsx
@@ -443,6 +443,7 @@ describe("useWaveformMode content-length cache lifecycle", () => {
     );
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(first.result.current.mode).toBe("normal");
+    first.unmount();
 
     const second = renderUseWaveformMode({
       playList: [track],

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/index.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/index.ts
@@ -2,5 +2,6 @@ export * from "./isLiveTrack";
 export * from "./useElementWidth";
 export * from "./useProgress";
 export * from "./useProgressKeyDown";
+export * from "./useTooltipPlacement";
 export * from "./useWaveformMode";
 export * from "./useWavesurfer";

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useProgress.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useProgress.ts
@@ -12,7 +12,7 @@ import {
 } from "react";
 import { isLiveTrack } from "./isLiveTrack";
 
-const SEEK_DEBOUNCE_MS = 120;
+export const SEEK_DEBOUNCE_MS = 120;
 
 type UseProgressResult = {
   progressProps: HTMLAttributes<HTMLDivElement>;
@@ -30,6 +30,9 @@ export const useProgress = (): UseProgressResult => {
 
   const seekTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSeekTimeRef = useRef<number | null>(null);
+  // Element captured on mousedown so the document-level drag can measure against
+  // it after the pointer leaves the bar (document events have no useful currentTarget).
+  const progressElRef = useRef<HTMLDivElement | null>(null);
 
   const commitSeek = useCallback(
     (time: number) => {
@@ -63,13 +66,13 @@ export const useProgress = (): UseProgressResult => {
 
   const getSeekTarget = useCallback(
     (
-      event: MouseEvent<HTMLDivElement>
+      clientX: number,
+      element: HTMLElement
     ): { ratio: number; time: number } | null => {
       if (!elementRefs?.audioEl || !isLoadedMetaData) return null;
       if (isLiveTrack(curTrack, elementRefs.audioEl.duration)) return null;
-      const { clientX } = event;
-      const { clientWidth } = event.currentTarget;
-      const boundingRect = event.currentTarget.getBoundingClientRect();
+      const { clientWidth } = element;
+      const boundingRect = element.getBoundingClientRect();
       const curPositionX = clientX - boundingRect.x;
       // Integer clientX vs fractional rect.x can push the raw ratio slightly
       // outside [0,1] at the edges — surfacing "--:--" or a time past the end.
@@ -83,41 +86,56 @@ export const useProgress = (): UseProgressResult => {
     [isLoadedMetaData, elementRefs?.audioEl, curTrack]
   );
 
-  const moveAudioTime = useCallback(
+  const handleMouseMove = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      const seekTarget = getSeekTarget(event);
-      if (!seekTarget) return;
+      const seekTarget = getSeekTarget(event.clientX, event.currentTarget);
+      // null = live track or metadata not loaded: no tooltip and no seek.
+      setHoverRatio(seekTarget ? seekTarget.ratio : null);
+      if (!isTimeChangeActive || !seekTarget) return;
       setPreviewRatio(seekTarget.ratio);
       scheduleSeek(seekTarget.time);
     },
-    [getSeekTarget, scheduleSeek]
-  );
-
-  const trackHover = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      const seekTarget = getSeekTarget(event);
-      // null = live track or metadata not loaded: no tooltip either
-      setHoverRatio(seekTarget ? seekTarget.ratio : null);
-    },
-    [getSeekTarget]
-  );
-
-  const handleMouseMove = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      trackHover(event);
-      if (isTimeChangeActive) moveAudioTime(event);
-    },
-    [trackHover, isTimeChangeActive, moveAudioTime]
+    [getSeekTarget, isTimeChangeActive, scheduleSeek]
   );
 
   const clickSeek = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      const seekTarget = getSeekTarget(event);
+      const seekTarget = getSeekTarget(event.clientX, event.currentTarget);
       if (!seekTarget) return;
       commitSeek(seekTarget.time);
     },
     [getSeekTarget, commitSeek]
   );
+
+  useEffect(() => {
+    if (!isTimeChangeActive) return;
+
+    const handleDocumentMouseMove = (event: globalThis.MouseEvent) => {
+      const element = progressElRef.current;
+      if (!element) return;
+      const seekTarget = getSeekTarget(event.clientX, element);
+      // Drives the active seek beyond the bar's bounds; mirrors handleMouseMove.
+      setHoverRatio(seekTarget ? seekTarget.ratio : null);
+      if (!seekTarget) return;
+      setPreviewRatio(seekTarget.ratio);
+      scheduleSeek(seekTarget.time);
+    };
+
+    const endDrag = () => {
+      setTimeChangeActive(false);
+      // Idempotent with the element onMouseUp for the same release: flushSeek
+      // early-returns once nothing is pending.
+      flushSeek();
+      setPreviewRatio(null);
+    };
+
+    document.addEventListener("mousemove", handleDocumentMouseMove);
+    document.addEventListener("mouseup", endDrag);
+    return () => {
+      document.removeEventListener("mousemove", handleDocumentMouseMove);
+      document.removeEventListener("mouseup", endDrag);
+    };
+  }, [isTimeChangeActive, getSeekTarget, scheduleSeek, flushSeek]);
 
   useEffect(() => {
     if (!isTimeChangeActive) return;
@@ -139,6 +157,7 @@ export const useProgress = (): UseProgressResult => {
     if (seekTimerRef.current) clearTimeout(seekTimerRef.current);
     seekTimerRef.current = null;
     pendingSeekTimeRef.current = null;
+    progressElRef.current = null;
     setPreviewRatio(null);
     setHoverRatio(null);
     setTimeChangeActive(false);
@@ -146,7 +165,10 @@ export const useProgress = (): UseProgressResult => {
 
   return {
     progressProps: {
-      onMouseDown: () => setTimeChangeActive(true),
+      onMouseDown: (event: MouseEvent<HTMLDivElement>) => {
+        progressElRef.current = event.currentTarget;
+        setTimeChangeActive(true);
+      },
       onMouseUp: () => {
         setTimeChangeActive(false);
         flushSeek();
@@ -156,10 +178,10 @@ export const useProgress = (): UseProgressResult => {
         setHoverRatio(null);
       },
       onMouseLeave: () => {
-        setTimeChangeActive(false);
-        flushSeek();
-        setPreviewRatio(null);
         setHoverRatio(null);
+        // Document mouseup owns end-of-drag now; only drop the preview when a
+        // drag isn't in progress so leaving the bar mid-drag keeps the cursor.
+        if (!isTimeChangeActive) setPreviewRatio(null);
       },
       onMouseMove: handleMouseMove,
       onClick: clickSeek,

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useProgress.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useProgress.ts
@@ -127,6 +127,9 @@ export const useProgress = (): UseProgressResult => {
       // early-returns once nothing is pending.
       flushSeek();
       setPreviewRatio(null);
+      // Released off the bar → no mouseleave fires; clear hover so the tooltip
+      // doesn't linger pinned at the clamped edge (mirrors element onMouseUp).
+      setHoverRatio(null);
     };
 
     document.addEventListener("mousemove", handleDocumentMouseMove);

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useTooltipPlacement.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useTooltipPlacement.ts
@@ -1,0 +1,16 @@
+import { useUIContext } from "@/components/AudioPlayer/Context/hooks/useUIContext";
+import { useAutoPlacement } from "@/components/AudioPlayer/Interface/hooks";
+import type { TooltipPlacement } from "@/components/Tooltip";
+
+export const useTooltipPlacement = (
+  wrapperRef: React.RefObject<HTMLElement>
+): TooltipPlacement => {
+  const { timeTooltipPlacement } = useUIContext();
+  const autoPlacement = useAutoPlacement({
+    triggerRef: wrapperRef,
+    initialState: "top",
+  });
+  return (
+    timeTooltipPlacement ?? (autoPlacement === "bottom" ? "bottom" : "top")
+  );
+};

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
@@ -24,6 +24,9 @@ const HEAD_TIMEOUT_MS = 8000;
 // One HEAD per src, reused across re-renders, track revisits, and any AudioPlayer instances sharing the src.
 const contentLengthCache = new Map<string, Promise<number | null>>();
 
+// Distinct track sources must not grow the cache without bound; evict oldest.
+const MAX_CONTENT_LENGTH_CACHE = 100;
+
 // Warn once per src across those same re-renders / revisits / shared instances.
 const warnedLargeFileSrc = new Set<string>();
 
@@ -37,14 +40,25 @@ const fetchContentLength = (src: string): Promise<number | null> => {
   const cached = contentLengthCache.get(src);
   if (cached) return cached;
 
+  if (contentLengthCache.size >= MAX_CONTENT_LENGTH_CACHE) {
+    const oldestSrc = contentLengthCache.keys().next().value;
+    if (oldestSrc !== undefined) contentLengthCache.delete(oldestSrc);
+  }
+
   const pending: Promise<number | null> = fetchWithTimeout(
     src,
     { method: "HEAD" },
     HEAD_TIMEOUT_MS
   ).then((res) => {
-    if (!res) return null;
-    const header = res.headers.get("content-length");
-    return header ? Number(header) : null;
+    const header = res?.headers.get("content-length");
+    const bytes = header != null ? Number(header) : null;
+    if (bytes == null || !Number.isFinite(bytes)) {
+      // Only a definitive byte count deserves to stick; drop transient failures
+      // (no response / missing header / unparsable) so a later attempt retries.
+      contentLengthCache.delete(src);
+      return null;
+    }
+    return bytes;
   });
 
   contentLengthCache.set(src, pending);

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
@@ -50,14 +50,16 @@ const fetchContentLength = (src: string): Promise<number | null> => {
     { method: "HEAD" },
     HEAD_TIMEOUT_MS
   ).then((res) => {
-    const header = res?.headers.get("content-length");
-    const bytes = header != null ? Number(header) : null;
-    if (bytes == null || !Number.isFinite(bytes)) {
-      // Only a definitive byte count deserves to stick; drop transient failures
-      // (no response / missing header / unparsable) so a later attempt retries.
+    if (!res) {
+      // No response (network error / timeout) is transient — drop so a later
+      // attempt retries. A response (even a 200 without content-length) is a
+      // stable property of the src, so its verdict stays cached: one HEAD per src.
       contentLengthCache.delete(src);
       return null;
     }
+    const header = res.headers.get("content-length");
+    const bytes = header != null ? Number(header) : null;
+    if (bytes == null || !Number.isFinite(bytes)) return null;
     return bytes;
   });
 

--- a/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
+++ b/package/src/components/AudioPlayer/Interface/Controller/Input/Progress/hooks/useWaveformMode.ts
@@ -54,7 +54,10 @@ const fetchContentLength = (src: string): Promise<number | null> => {
       // No response (network error / timeout) is transient — drop so a later
       // attempt retries. A response (even a 200 without content-length) is a
       // stable property of the src, so its verdict stays cached: one HEAD per src.
-      contentLengthCache.delete(src);
+      // Guard the delete: an older probe failing late must not evict a newer
+      // promise that has since replaced this src's entry.
+      if (contentLengthCache.get(src) === pending)
+        contentLengthCache.delete(src);
       return null;
     }
     const header = res.headers.get("content-length");


### PR DESCRIPTION
## Summary

Bundles the actionable CodeRabbit review follow-ups scoped to the progress controls (all in `package/src/.../Progress/`). Targets `main` as a patch on the shipped v2.4.x code; ships under `v2.4.2`.

## Changes

- **Drag-seek continues beyond the bar (1)** — `useProgress` now attaches document-level `mousemove`/`mouseup` once a drag starts, so moving the pointer off the bar (or releasing anywhere on the page) no longer aborts the seek. `onMouseLeave` is reduced to clearing the hover tooltip only; document `mouseup` owns end-of-drag.
- **Single measure per mouse event (2)** — the pointer position (one `getBoundingClientRect`) is computed once per event and reused for both the hover tooltip and the scheduled seek.
- **Probe cache lifecycle (3)** — `fetchContentLength` no longer caches transient `HEAD` failures (no response / missing `Content-Length`), so a later attempt can retry; successful probes stay cached and in-flight-deduped, and the cache is now size-bounded.
- **Shared tooltip placement (4)** — extracted the duplicated placement resolution into a `useTooltipPlacement` hook used by both `BarProgress` and `WaveformProgress` (no behavior change). `SEEK_DEBOUNCE_MS` is exported for test reuse (5).

## Test Results

- [x] tests pass — full suite **447 passing** (`npx vitest run`), incl. new regression cases: drag-beyond-bar seek, document mouseup flush, mouseleave no longer ends a drag, probe-cache retry + concurrent dedup
- [x] typecheck passes (`tsc --noEmit`)
- [x] lint/prettier pass (pre-commit)

Independent edge-case review agent was run on the diff; findings triaged before merge.

## Related Issues

CodeRabbit review follow-ups from PR #82. No public API change; internal hooks + behavior only. Ships in `v2.4.2` alongside #82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drag seeking on the audio progress bar no longer aborts when the pointer leaves the bar; the drag now ends cleanly on mouse release.
  * Oversize checks for remote audio using `HEAD` probes no longer permanently cache transient failures, allowing later retries to recover.
  * Tooltip placement is now consistent across the progress bar and waveform controls.
* **Performance**
  * Improved drag interaction handling to reduce unnecessary recalculation while preserving accurate seek preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
