### PR TITLE
fix(compound): declare slot identity explicitly

### DIFF
--- a/package/src/components/AudioPlayer/Interface/compound/__tests__/slotMetaMap.test.tsx
+++ b/package/src/components/AudioPlayer/Interface/compound/__tests__/slotMetaMap.test.tsx
@@ -1,0 +1,58 @@
+import { createElement, memo } from "react";
+import { describe, expect, it } from "vitest";
+import AudioPlayer from "@/components/AudioPlayer";
+import {
+  SLOT_ID,
+  compoundSlotMetaMap,
+  resolveSlotKey,
+  withSlotIds,
+} from "../slotMetaMap";
+
+// Slot keys exposed on the compound namespace. Every one of these must carry a
+// declared identity — identity used to be inferred from the component function
+// name, which minified builds rename.
+const NAMESPACE_SLOT_KEYS = [
+  "Progress",
+  "Volume",
+  "PlayList",
+  "PlayListEmpty",
+  "PlayButton",
+  "RepeatButton",
+  "SpeedSelector",
+  "Artwork",
+  "TrackInfo",
+  "TrackTime",
+  "CustomComponent",
+] as const;
+
+describe("slot identity", () => {
+  it.each(NAMESPACE_SLOT_KEYS)(
+    "stamps '%s' with a slot id matching its namespace key",
+    (slotKey) => {
+      const component = AudioPlayer[slotKey] as Record<string, unknown>;
+      expect(component[SLOT_ID]).toBe(slotKey);
+    }
+  );
+
+  it.each(Object.keys(compoundSlotMetaMap))(
+    "exposes meta entry '%s' on the compound namespace",
+    (metaKey) => {
+      expect(NAMESPACE_SLOT_KEYS).toContain(metaKey);
+    }
+  );
+
+  it("resolves the id through a memo wrapper", () => {
+    const Wrapped = memo(function Inner() {
+      return null;
+    });
+    const { Stamped } = withSlotIds({ Stamped: Wrapped });
+
+    expect(resolveSlotKey(createElement(Stamped))).toBe("Stamped");
+  });
+
+  it("returns undefined for a component that was never stamped", () => {
+    const Foreign = () => null;
+
+    expect(resolveSlotKey(createElement(Foreign))).toBeUndefined();
+  });
+});

--- a/package/src/components/AudioPlayer/Interface/compound/slotMetaMap.ts
+++ b/package/src/components/AudioPlayer/Interface/compound/slotMetaMap.ts
@@ -4,20 +4,27 @@ import { ActiveUI } from "@/components/AudioPlayer/Context/StateContext";
 export type ActiveUIKey = keyof ActiveUI;
 
 export interface SlotMeta {
-  displayName: string;
   activeUIKey: ActiveUIKey;
 }
 
+// Slot identity is declared, not inferred. Minified builds rename component
+// functions, and React's production `memo` — unlike the development build —
+// does not copy `displayName` onto the wrapped function, so neither `.name`
+// nor `.displayName` survives a published bundle.
+export const SLOT_ID = "__rmapSlotId";
+
+type SlotCarrier = { [SLOT_ID]?: string };
+
 export const compoundSlotMetaMap: Record<string, SlotMeta> = {
-  Progress: { displayName: "Progress", activeUIKey: "progress" },
-  Volume: { displayName: "Volume", activeUIKey: "volume" },
-  SortablePlayList: { displayName: "PlayList", activeUIKey: "playList" },
-  TransportControls: { displayName: "PlayButton", activeUIKey: "playButton" },
-  RepeatTypeBtn: { displayName: "RepeatButton", activeUIKey: "repeatType" },
-  Artwork: { displayName: "Artwork", activeUIKey: "artwork" },
-  TrackInfo: { displayName: "TrackInfo", activeUIKey: "trackInfo" },
-  TrackTime: { displayName: "TrackTime", activeUIKey: "trackTime" },
-  SpeedSelector: { displayName: "SpeedSelector", activeUIKey: "playbackRate" },
+  Progress: { activeUIKey: "progress" },
+  Volume: { activeUIKey: "volume" },
+  PlayList: { activeUIKey: "playList" },
+  PlayButton: { activeUIKey: "playButton" },
+  RepeatButton: { activeUIKey: "repeatType" },
+  Artwork: { activeUIKey: "artwork" },
+  TrackInfo: { activeUIKey: "trackInfo" },
+  TrackTime: { activeUIKey: "trackTime" },
+  SpeedSelector: { activeUIKey: "playbackRate" },
 };
 
 export function isPresetActive(activeUI: ActiveUI, key: ActiveUIKey): boolean {
@@ -27,16 +34,19 @@ export function isPresetActive(activeUI: ActiveUI, key: ActiveUIKey): boolean {
   return Boolean(activeUI.all);
 }
 
-// Unwrap one layer of memo/forwardRef — wrappers hide the inner `.name`.
+// Stamps each entry's key onto the component it points at, so the key the
+// consumer writes (`<AudioPlayer.Progress/>`) is the key resolved at runtime.
+// Stamping the outer object matters: `child.type` is the memo wrapper, not the
+// function inside it.
+export function withSlotIds<TSlots extends Record<string, unknown>>(
+  slots: TSlots
+): TSlots {
+  Object.entries(slots).forEach(([slotId, component]) => {
+    (component as SlotCarrier)[SLOT_ID] = slotId;
+  });
+  return slots;
+}
+
 export function resolveSlotKey(child: ReactElement): string | undefined {
-  const outer = child.type as
-    | {
-        name?: string;
-        displayName?: string;
-        type?: { name?: string; displayName?: string };
-      }
-    | undefined;
-  if (!outer) return undefined;
-  const inner = outer.type ?? outer;
-  return inner.displayName || inner.name || undefined;
+  return (child.type as SlotCarrier | undefined)?.[SLOT_ID];
 }

--- a/package/src/components/AudioPlayer/Interface/compound/useDuplicateSlotWarning.ts
+++ b/package/src/components/AudioPlayer/Interface/compound/useDuplicateSlotWarning.ts
@@ -21,6 +21,10 @@ export function useDuplicateSlotWarning({
     .sort()
     .join(",");
 
+  const unrecognizedCount = compoundChildren.filter(
+    (child) => !resolveSlotKey(child)
+  ).length;
+
   useEffect(() => {
     if (process.env.NODE_ENV === "production") return;
     if (!compoundSignature) return;
@@ -29,14 +33,24 @@ export function useDuplicateSlotWarning({
     for (const key of compoundSignature.split(",")) {
       const meta = compoundSlotMetaMap[key];
       if (!meta) continue;
-      if (seen.has(meta.displayName)) continue;
+      if (seen.has(key)) continue;
       if (!isPresetActive(activeUI, meta.activeUIKey)) continue;
-      seen.add(meta.displayName);
+      seen.add(key);
       // eslint-disable-next-line no-console
       console.warn(
-        `[react-modern-audio-player] Both preset and compound '${meta.displayName}' are rendered. ` +
+        `[react-modern-audio-player] Both preset and compound '${key}' are rendered. ` +
           `Set \`activeUI.${meta.activeUIKey}=false\` to replace the preset control.`
       );
     }
   }, [compoundSignature, activeUI]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (!unrecognizedCount) return;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[react-modern-audio-player] ${unrecognizedCount} child(ren) are not recognized slots ` +
+        `and will not receive a grid area. Wrap custom content in \`AudioPlayer.CustomComponent\`.`
+    );
+  }, [unrecognizedCount]);
 }

--- a/package/src/components/AudioPlayer/index.tsx
+++ b/package/src/components/AudioPlayer/index.tsx
@@ -8,6 +8,7 @@ import "@/styles/GlobalStyle.css";
 import { DEFAULT_INTERFACE_GRID_BOUND } from "./Context";
 import { CustomComponent } from "./Interface/CustomComponent";
 import { PlayListEmpty } from "./Interface/PlayListEmpty";
+import { withSlotIds } from "./Interface/compound/slotMetaMap";
 import { AudioPlayer, AudioPlayerProps } from "./Player";
 import { Progress } from "./Interface/Controller/Input";
 import { Volume } from "./Interface/Controller/Volume";
@@ -61,18 +62,21 @@ type AudioPlayerComponent = typeof AudioPlayerWithProviders & {
   CustomComponent: typeof CustomComponent;
 };
 
-const AudioPlayerCompound = Object.assign(AudioPlayerWithProviders, {
-  Progress,
-  Volume,
-  PlayList: SortablePlayList,
-  PlayListEmpty,
-  PlayButton: TransportControls,
-  RepeatButton: RepeatTypeBtn,
-  SpeedSelector,
-  Artwork,
-  TrackInfo,
-  TrackTime,
-  CustomComponent,
-}) as AudioPlayerComponent;
+const AudioPlayerCompound = Object.assign(
+  AudioPlayerWithProviders,
+  withSlotIds({
+    Progress,
+    Volume,
+    PlayList: SortablePlayList,
+    PlayListEmpty,
+    PlayButton: TransportControls,
+    RepeatButton: RepeatTypeBtn,
+    SpeedSelector,
+    Artwork,
+    TrackInfo,
+    TrackTime,
+    CustomComponent,
+  })
+) as AudioPlayerComponent;
 
 export default AudioPlayerCompound;


### PR DESCRIPTION
## Summary

Compound slots were identified at runtime by reading the component function's `.name` / `.displayName`. Minified builds rename those bindings, so **every compound slot failed to resolve in a published bundle** — compound children received no grid area, and the preset/compound duplicate warning never fired. The existing integration test passed the whole time because Vitest does not minify.

Verified against the built artifact before the fix (`dist/index.es.js`, React production build):

```
Progress -> "kt"      PlayButton   -> "yt"      RepeatButton -> undefined
Volume   -> "_t"      TrackTime    -> "Dt"      Artwork      -> undefined
PlayList -> "gt"      SpeedSelector / TrackInfo -> undefined
```

`SpeedSelector` and `TrackInfo` appear to work in development only: React's development `memo` copies `displayName` onto the wrapped function, and the production build does not. Setting `displayName` on a `memo` wrapper is therefore not a reliable identity.

After the fix, all 11 namespace entries resolve to their own key in the same production probe.

## Changes

- `Interface/compound/slotMetaMap.ts`
  - adds `withSlotIds`, which stamps each compound namespace key onto the component it points at
  - `resolveSlotKey` now reads only the declared id — name inference and the `memo` / `forwardRef` unwrapping it required are removed
  - `compoundSlotMetaMap` re-keyed from internal component names to the public slot names, making the former `displayName` field redundant
- `AudioPlayer/index.tsx` — compound namespace wrapped in `withSlotIds`, so a new slot cannot be added without an identity
- `Interface/compound/useDuplicateSlotWarning.ts` — uses the slot key directly; adds a development-only warning for children that carry no slot id (children that have an id but no meta entry, i.e. `CustomComponent`, stay silent because that is normal usage)
- `Interface/compound/__tests__/slotMetaMap.test.tsx` — new, 22 tests

### Why the fallback was removed rather than kept

A name-inference fallback reads like a safety net, but it is what turned a build-time break into a silent one: it resolved correctly in development, so the failure only appeared in published packages. Removing it makes the same class of mistake fail loudly and immediately.

## Test Results

- [x] build passes — `yarn build`
- [x] lint passes — pre-commit `eslint` + `prettier`
- [x] tests pass — 473 passed / 39 files (was 451 / 38)
- [x] typecheck passes — `yarn typeCheck`
- [x] production-build probe: 11/11 slots resolve to their namespace key
- [x] mutation check: removing the stamping makes 12 of the new tests fail

## Checklist

- [x] commit messages follow Conventional Commits format
- [x] no unrelated changes included
- [x] `package/README.md` reviewed — not updated; public export surface is unchanged (28 runtime exports before and after, `withSlotIds` / `SLOT_ID` absent from `dist/index.d.ts`)
- [x] `package/CHANGELOG.md` — no breaking changes

## Follow-up (not in this PR)

No test loads the built artifact, which is why this bug survived. A build-and-probe smoke check in CI would close that gap; it needs a workflow change and is left out to keep this PR to one concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AudioPlayer compound component slot identification, including support for memoized components.
  - Corrected slot mappings for playlist, play button, and repeat button controls.
  - Improved duplicate-slot detection and warnings for unrecognized custom children.
- **Tests**
  - Added coverage to verify slot identities, mappings, wrapped components, and handling of unsupported components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->