### PR TITLE
📝 docs(readme): correct the context hook return shapes

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -619,7 +619,7 @@ const MyComponent = () => {
 | `useTrackContext`      | `{ playList, curPlayId, curIdx }`                                                                                                                                                  |
 | `useUIContext`         | `{ activeUI, playListPlacement, playerPlacement?, interfacePlacement?, volumeSliderPlacement?, speedSelectorPlacement?, timeTooltipPlacement?, colorScheme?, playListExpanded? }` |
 | `useResourceContext`   | `{ elementRefs?, customIcons?, coverImgsCss? }`                                                                                                                                    |
-| `useAudioAttrsContext` | native `<audio>` attributes passed via `audioInitialState` (excludes `volume`, `muted`, `src`)                                                                                     |
+| `useAudioAttrsContext` | native `<audio>` attributes from `audioInitialState`, minus every field the player manages itself (playback state, `volume`/`muted`, `playbackRate`, `curPlayId`, `playListExpanded`); the element's `src` always comes from the current track                                                                                     |
 | `useCurrentTrack`      | `AudioData \| undefined` — derived value, not a context subscription; finds the current track in `playList` by `curPlayId`                                                        |
 
 # Custom Component

--- a/package/README.md
+++ b/package/README.md
@@ -597,24 +597,30 @@ Components inside `AudioPlayer` can subscribe to only the state slice they need,
 
 ```tsx
 import {
-  usePlaybackContext, // curAudioState: { isPlaying, repeatType, volume, muted, isLoadedMetaData }
-  useTrackContext, // playList, curIdx, curPlayId
-  useUIContext, // activeUI, interfacePlacement, playListPlacement, playerPlacement, volumeSliderPlacement
+  usePlaybackContext, // isPlaying, volume, muted, repeatType, isLoadedMetaData, audioResetKey, playbackRate
+  useTimeContext, // currentTime, duration, seekRequestKey
+  useTrackContext, // playList, curPlayId, curIdx
+  useUIContext, // activeUI, playListPlacement, playerPlacement, interfacePlacement, volumeSliderPlacement, speedSelectorPlacement, timeTooltipPlacement, colorScheme, playListExpanded
   useResourceContext, // elementRefs, customIcons, coverImgsCss
+  useAudioAttrsContext, // native <audio> attributes passed via audioInitialState
+  useCurrentTrack, // current AudioData, derived from useTrackContext — not a direct context subscription
 } from "react-modern-audio-player";
 
 const MyComponent = () => {
-  const { curAudioState } = usePlaybackContext();
-  return <span>{curAudioState.isPlaying ? "Playing" : "Paused"}</span>;
+  const { isPlaying } = usePlaybackContext();
+  return <span>{isPlaying ? "Playing" : "Paused"}</span>;
 };
 ```
 
-| Hook                 | Returns                                                                                       |
-| -------------------- | --------------------------------------------------------------------------------------------- |
-| `usePlaybackContext` | `{ curAudioState: AudioState }`                                                               |
-| `useTrackContext`    | `{ playList, curIdx, curPlayId }`                                                             |
-| `useUIContext`       | `{ activeUI, interfacePlacement, playListPlacement, playerPlacement, volumeSliderPlacement }` |
-| `useResourceContext` | `{ elementRefs, customIcons, coverImgsCss }`                                                  |
+| Hook                   | Returns                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `usePlaybackContext`   | `{ isPlaying, volume, muted, repeatType, isLoadedMetaData, audioResetKey, playbackRate }`                                                                                          |
+| `useTimeContext`       | `{ currentTime, duration, seekRequestKey }`                                                                                                                                        |
+| `useTrackContext`      | `{ playList, curPlayId, curIdx }`                                                                                                                                                  |
+| `useUIContext`         | `{ activeUI, playListPlacement, playerPlacement?, interfacePlacement?, volumeSliderPlacement?, speedSelectorPlacement?, timeTooltipPlacement?, colorScheme?, playListExpanded? }` |
+| `useResourceContext`   | `{ elementRefs?, customIcons?, coverImgsCss? }`                                                                                                                                    |
+| `useAudioAttrsContext` | native `<audio>` attributes passed via `audioInitialState` (excludes `volume`, `muted`, `src`)                                                                                     |
+| `useCurrentTrack`      | `AudioData \| undefined` — derived value, not a context subscription; finds the current track in `playList` by `curPlayId`                                                        |
 
 # Custom Component
 


### PR DESCRIPTION
## Summary

Documentation half of issue 87, split out from the code fix.

The Context Hooks section still described the pre-v2 nested return shape:
`usePlaybackContext()` was documented as returning `{ curAudioState }`, so the
example's `curAudioState.isPlaying` throws against the current flat context. The
table listed four hooks with the same stale shapes.

The snippet and table now show the flat shapes each hook actually returns, and
the three hooks that were missing from the list (`useTimeContext`,
`useAudioAttrsContext`, `useCurrentTrack`) are included — all seven are exported
from the package root.

No source changes; documentation only.

## Changes

- `package/README.md` — Context Hooks example and table rewritten to the flat shapes

## Test Results

- [x] documented shapes verified field-for-field against `PlaybackContext.ts`,
      `TimeContext.ts`, `TrackContext.ts`, `UIContext.ts`, `ResourceContext.ts`,
      `useCurrentTrack.ts`
- [x] every documented hook confirmed exported via `Context/hooks/index.ts` → `src/index.ts`
- [ ] no build/test impact (documentation only)

## Related Issues

Part of #87 — the code half (`CustomComponent` dropping `playbackRate`) is a separate pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Context Hooks documentation with separate playback, time, track, UI, resource, audio-attribute, and current-track hooks.
  * Documented expanded playback, UI, and resource context fields, including playback rate, placement options, color scheme, and playlist state.
  * Clarified hook return values and added documentation for time and current-track access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->